### PR TITLE
Record invocations

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "typescript": "^3.7.4"
   },
   "resolutions": {
-    "**/graphql": "15.0.0-alpha.2"
+    "**/graphql": "15.0.0-rc.1"
   }
 }

--- a/packages/authx/package.json
+++ b/packages/authx/package.json
@@ -14,11 +14,11 @@
     "@types/koa": "2.11.0",
     "@types/koa-router": "^7.0.42",
     "@types/koa-send": "^4.1.2",
-    "@types/pg": "^7.14.0",
+    "@types/pg": "^7.14.1",
     "@types/uuid": "^3.4.6",
     "auth-header": "^1.0.0",
     "form-data": "^3.0.0",
-    "graphql": "15.0.0-alpha.2",
+    "graphql": "15.0.0-rc.1",
     "graphql-api-koa": "^2.2.0",
     "graphql-playground-middleware-koa": "^1.6.12",
     "graphql-relay": "^0.6.0",
@@ -32,8 +32,8 @@
   },
   "description": "",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.11.0",
-    "@typescript-eslint/parser": "^2.11.0",
+    "@typescript-eslint/eslint-plugin": "^2.15.0",
+    "@typescript-eslint/parser": "^2.15.0",
     "ava": "^2.4.0",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",
@@ -80,6 +80,6 @@
   "types": "dist/index.d.ts",
   "version": "2.0.7",
   "resolutions": {
-    "**/graphql": "15.0.0-alpha.2"
+    "**/graphql": "15.0.0-rc.1"
   }
 }

--- a/packages/authx/schema.sql
+++ b/packages/authx/schema.sql
@@ -56,6 +56,7 @@ CREATE TABLE authx.authority_record (
 ) INHERITS (authx.record);
 
 CREATE UNIQUE INDEX ON authx.authority_record USING BTREE (entity_id) WHERE replacement_record_id IS NULL;
+CREATE UNIQUE INDEX ON authx.authority_record USING BTREE (entity_id, record_id);
 
 
 
@@ -73,6 +74,7 @@ CREATE TABLE authx.client_record (
 ) INHERITS (authx.record);
 
 CREATE UNIQUE INDEX ON authx.client_record USING BTREE (entity_id) WHERE replacement_record_id IS NULL;
+CREATE UNIQUE INDEX ON authx.client_record USING BTREE (entity_id, record_id);
 
 
 
@@ -91,6 +93,7 @@ CREATE TABLE authx.credential_record (
 
 CREATE UNIQUE INDEX ON authx.credential_record USING BTREE (entity_id) WHERE replacement_record_id IS NULL;
 CREATE UNIQUE INDEX ON authx.credential_record USING BTREE (authority_id, authority_user_id) WHERE replacement_record_id IS NULL AND enabled = TRUE;
+CREATE UNIQUE INDEX ON authx.credential_record USING BTREE (entity_id, record_id);
 
 
 
@@ -110,6 +113,7 @@ CREATE TABLE authx.grant_record (
 
 CREATE UNIQUE INDEX ON authx.grant_record USING BTREE (entity_id) WHERE replacement_record_id IS NULL;
 CREATE UNIQUE INDEX ON authx.grant_record USING BTREE (user_id, client_id) WHERE replacement_record_id IS NULL AND enabled = TRUE;
+CREATE UNIQUE INDEX ON authx.grant_record USING BTREE (entity_id, record_id);
 
 
 
@@ -126,6 +130,7 @@ CREATE TABLE authx.role_record (
 ) INHERITS (authx.record);
 
 CREATE UNIQUE INDEX ON authx.role_record USING BTREE (entity_id) WHERE replacement_record_id IS NULL;
+CREATE UNIQUE INDEX ON authx.role_record USING BTREE (entity_id, record_id);
 
 CREATE TABLE authx.role_record_user (
   role_record_id UUID NOT NULL REFERENCES authx.role_record,
@@ -150,6 +155,7 @@ CREATE TABLE authx.authorization_record (
 ) INHERITS (authx.record);
 
 CREATE UNIQUE INDEX ON authx.authorization_record USING BTREE (entity_id) WHERE replacement_record_id IS NULL;
+CREATE UNIQUE INDEX ON authx.authorization_record USING BTREE (entity_id, record_id);
 
 
 
@@ -165,7 +171,50 @@ CREATE TABLE authx.user_record (
 ) INHERITS (authx.record);
 
 CREATE UNIQUE INDEX ON authx.user_record USING BTREE (entity_id) WHERE replacement_record_id IS NULL;
+CREATE UNIQUE INDEX ON authx.user_record USING BTREE (entity_id, record_id);
 
 
 
+
+-- Invocations
+-- ===========
+
+CREATE TABLE authx.invocation (
+  invocation_id UUID PRIMARY KEY,
+  entity_id UUID NOT NULL REFERENCES authx.entity,
+  record_id UUID NOT NULL REFERENCES authx.record,
+  success BOOLEAN NOT NULL,
+  created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CHECK (false) NO INHERIT
+);
+
+CREATE TABLE authx.credential_invocation (
+  PRIMARY KEY (invocation_id),
+  FOREIGN KEY (record_id) REFERENCES authx.credential_record,
+  FOREIGN KEY (entity_id) REFERENCES authx.credential,
+  FOREIGN KEY (entity_id, record_id) REFERENCES authx.credential_record(entity_id, record_id)
+) INHERITS (authx.invocation);
+
+CREATE TABLE authx.authorization_invocation (
+  format TEXT NOT NULL,
+  PRIMARY KEY (invocation_id),
+  FOREIGN KEY (record_id) REFERENCES authx.authorization_record,
+  FOREIGN KEY (entity_id) REFERENCES authx.authorization,
+  FOREIGN KEY (entity_id, record_id) REFERENCES authx.authorization_record(entity_id, record_id)
+) INHERITS (authx.invocation);
+
+CREATE TABLE authx.grant_invocation (
+  PRIMARY KEY (invocation_id),
+  FOREIGN KEY (record_id) REFERENCES authx.grant_record,
+  FOREIGN KEY (entity_id) REFERENCES authx.grant,
+  FOREIGN KEY (entity_id, record_id) REFERENCES authx.grant_record(entity_id, record_id)
+) INHERITS (authx.invocation);
+
+CREATE TABLE authx.client_invocation (
+  PRIMARY KEY (invocation_id),
+  FOREIGN KEY (record_id) REFERENCES authx.client_record,
+  FOREIGN KEY (entity_id) REFERENCES authx.client,
+  FOREIGN KEY (entity_id, record_id) REFERENCES authx.client_record(entity_id, record_id)
+) INHERITS (authx.invocation);
 

--- a/packages/authx/schema.sql
+++ b/packages/authx/schema.sql
@@ -183,7 +183,6 @@ CREATE TABLE authx.invocation (
   invocation_id UUID PRIMARY KEY,
   entity_id UUID NOT NULL REFERENCES authx.entity,
   record_id UUID NOT NULL REFERENCES authx.record,
-  success BOOLEAN NOT NULL,
   created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
   CHECK (false) NO INHERIT

--- a/packages/authx/src/graphql/GraphQLAuthorization.ts
+++ b/packages/authx/src/graphql/GraphQLAuthorization.ts
@@ -8,6 +8,7 @@ import {
 } from "graphql";
 
 import jwt from "jsonwebtoken";
+import v4 from "uuid/v4";
 import { Grant, Authorization, User } from "../model";
 import { Context } from "../Context";
 import { GraphQLExplanation } from "./GraphQLExplanation";
@@ -219,6 +220,13 @@ export const GraphQLAuthorization: GraphQLObjectType<
               currentClientId: (await a.grant(tx))?.clientId ?? null
             };
 
+            const tokenId = v4();
+            await authorization.invoke(tx, {
+              id: tokenId,
+              format: "bearer",
+              createdAt: new Date()
+            });
+
             return `Bearer ${jwt.sign(
               {
                 aid: authorization.id,
@@ -226,6 +234,7 @@ export const GraphQLAuthorization: GraphQLObjectType<
               },
               privateKey,
               {
+                jwtid: tokenId,
                 algorithm: "RS512",
                 expiresIn: jwtValidityDuration,
                 subject: authorization.userId,

--- a/packages/authx/src/model/Authority.ts
+++ b/packages/authx/src/model/Authority.ts
@@ -4,6 +4,30 @@ import { Authorization } from "./Authorization";
 import { NotFoundError } from "../errors";
 import { AuthorityAction, createV2AuthXScope } from "../util/scopes";
 
+export interface AuthorityInvocationData {
+  readonly id: string;
+  readonly entityId: string;
+  readonly recordId: null | string;
+  readonly success: boolean;
+  readonly createdAt: Date;
+}
+
+export class AuthorityInvocation implements AuthorityInvocationData {
+  public readonly id: string;
+  public readonly entityId: string;
+  public readonly recordId: null | string;
+  public readonly success: boolean;
+  public readonly createdAt: Date;
+
+  constructor(data: AuthorityInvocationData) {
+    this.id = data.id;
+    this.entityId = data.entityId;
+    this.recordId = data.recordId;
+    this.success = data.success;
+    this.createdAt = data.createdAt;
+  }
+}
+
 export interface AuthorityRecordData {
   readonly id: string;
   readonly replacementRecordId: null | string;
@@ -127,6 +151,79 @@ export abstract class Authority<A> implements AuthorityData<A> {
           createdByAuthorizationId: row.created_by_authorization_id,
           createdAt: row.created_at,
           entityId: row.entity_id
+        })
+    );
+  }
+
+  public async invoke(
+    tx: PoolClient,
+    data: {
+      id: string;
+      success: boolean;
+      createdAt: Date;
+    }
+  ): Promise<AuthorityInvocation> {
+    // insert the new invocation
+    const result = await tx.query(
+      `
+      INSERT INTO authx.authorization_invocation
+      (
+        invocation_id,
+        entity_id,
+        record_id,
+        created_at,
+        success
+      )
+      VALUES
+        ($1, $2, $3, $4, $5, $6)
+      RETURNING
+        invocation_id AS id,
+        entity_id,
+        record_id,
+        created_at,
+        success
+      `,
+      [data.id, this.id, this.recordId, data.createdAt, data.success]
+    );
+
+    if (result.rows.length !== 1) {
+      throw new Error("INVARIANT: Insert must return exactly one row.");
+    }
+
+    const row = result.rows[0];
+
+    return new AuthorityInvocation({
+      id: row.id,
+      entityId: row.entity_id,
+      recordId: row.record_id,
+      success: row.success,
+      createdAt: row.created_at
+    });
+  }
+
+  public async invocations(tx: PoolClient): Promise<AuthorityInvocation[]> {
+    const result = await tx.query(
+      `
+      SELECT
+        invocation_id as id,
+        record_id,
+        entity_id,
+        success,
+        created_at,
+      FROM authx.authorization_invocation
+      WHERE entity_id = $1
+      ORDER BY created_at DESC
+      `,
+      [this.id]
+    );
+
+    return result.rows.map(
+      row =>
+        new AuthorityInvocation({
+          ...row,
+          recordId: row.record_id,
+          entityId: row.entity_id,
+          createdAt: row.created_at
         })
     );
   }

--- a/packages/authx/src/model/Authority.ts
+++ b/packages/authx/src/model/Authority.ts
@@ -132,14 +132,14 @@ export abstract class Authority<A> implements AuthorityData<A> {
   }
 
   public static read<T extends Authority<any>>(
-    this: new (data: AuthorityData<any>) => T,
+    this: new (data: AuthorityData<any> & { readonly recordId: string }) => T,
     tx: PoolClient,
     id: string,
     options?: { forUpdate: boolean }
   ): Promise<T>;
 
   public static read<T extends Authority<any>>(
-    this: new (data: AuthorityData<any>) => T,
+    this: new (data: AuthorityData<any> & { readonly recordId: string }) => T,
     tx: PoolClient,
     id: string[],
     options?: { forUpdate: boolean }
@@ -147,7 +147,11 @@ export abstract class Authority<A> implements AuthorityData<A> {
 
   public static read<
     M extends {
-      [key: string]: { new (data: AuthorityData<any>): Authority<any> };
+      [key: string]: {
+        new (
+          data: AuthorityData<any> & { readonly recordId: string }
+        ): Authority<any>;
+      };
     },
     K extends keyof M
   >(
@@ -159,7 +163,11 @@ export abstract class Authority<A> implements AuthorityData<A> {
 
   public static read<
     M extends {
-      [key: string]: { new (data: AuthorityData<any>): Authority<any> };
+      [key: string]: {
+        new (
+          data: AuthorityData<any> & { readonly recordId: string }
+        ): Authority<any>;
+      };
     },
     K extends keyof M
   >(
@@ -177,7 +185,7 @@ export abstract class Authority<A> implements AuthorityData<A> {
     K extends keyof M
   >(
     this: {
-      new (data: AuthorityData<any>): T;
+      new (data: AuthorityData<any> & { readonly recordId: string }): T;
     },
     tx: PoolClient,
     id: string[] | string,
@@ -247,7 +255,7 @@ export abstract class Authority<A> implements AuthorityData<A> {
 
   public static async write<T extends Authority<any>>(
     this: {
-      new (data: AuthorityData<any>): T;
+      new (data: AuthorityData<any> & { readonly recordId: string }): T;
     },
     tx: PoolClient,
     data: AuthorityData<any>,

--- a/packages/authx/src/model/Authority.ts
+++ b/packages/authx/src/model/Authority.ts
@@ -15,14 +15,16 @@ export interface AuthorityData<A> {
 
 export abstract class Authority<A> implements AuthorityData<A> {
   public readonly id: string;
+  public readonly recordId: string;
   public readonly enabled: boolean;
   public readonly name: string;
   public readonly description: string;
   public readonly strategy: string;
   public readonly details: A;
 
-  public constructor(data: AuthorityData<A>) {
+  public constructor(data: AuthorityData<A> & { readonly recordId: string }) {
     this.id = data.id;
+    this.recordId = data.recordId;
     this.enabled = data.enabled;
     this.name = data.name;
     this.description = data.description;
@@ -137,6 +139,7 @@ export abstract class Authority<A> implements AuthorityData<A> {
       `
       SELECT
         entity_id AS id,
+        record_id,
         enabled,
         name,
         description,
@@ -164,6 +167,7 @@ export abstract class Authority<A> implements AuthorityData<A> {
     const data = result.rows.map(row => {
       return {
         ...row,
+        recordId: row.record_id,
         baseUrls: row.base_urls
       };
     });
@@ -252,6 +256,7 @@ export abstract class Authority<A> implements AuthorityData<A> {
         ($1, $2, $3, $4, $5, $6, $7, $8, $9)
       RETURNING
         entity_id AS id,
+        record_id,
         enabled,
         name,
         description,
@@ -278,6 +283,7 @@ export abstract class Authority<A> implements AuthorityData<A> {
     const row = next.rows[0];
     return new this({
       ...row,
+      recordId: row.record_id,
       baseUrls: row.base_urls
     });
   }

--- a/packages/authx/src/model/Authorization.ts
+++ b/packages/authx/src/model/Authorization.ts
@@ -16,6 +16,7 @@ export interface AuthorizationData {
 
 export class Authorization implements AuthorizationData {
   public readonly id: string;
+  public readonly recordId: string;
   public readonly enabled: boolean;
   public readonly userId: string;
   public readonly grantId: null | string;
@@ -26,8 +27,9 @@ export class Authorization implements AuthorizationData {
   private _grant: null | Promise<Grant> = null;
   private _authorization: null | Promise<Grant> = null;
 
-  public constructor(data: AuthorizationData) {
+  public constructor(data: AuthorizationData & { readonly recordId: string }) {
     this.id = data.id;
+    this.recordId = data.recordId;
     this.enabled = data.enabled;
     this.userId = data.userId;
     this.grantId = data.grantId;
@@ -196,6 +198,7 @@ export class Authorization implements AuthorizationData {
       row =>
         new Authorization({
           ...row,
+          recordId: row.record_id,
           userId: row.user_id,
           grantId: row.grant_id
         })
@@ -332,6 +335,7 @@ export class Authorization implements AuthorizationData {
     const row = next.rows[0];
     return new Authorization({
       ...row,
+      recordId: row.record_id,
       userId: row.user_id,
       grantId: row.grant_id
     });

--- a/packages/authx/src/model/Client.ts
+++ b/packages/authx/src/model/Client.ts
@@ -8,7 +8,6 @@ export interface ClientInvocationData {
   readonly id: string;
   readonly entityId: string;
   readonly recordId: null | string;
-  readonly success: boolean;
   readonly createdAt: Date;
 }
 
@@ -16,14 +15,12 @@ export class ClientInvocation implements ClientInvocationData {
   public readonly id: string;
   public readonly entityId: string;
   public readonly recordId: null | string;
-  public readonly success: boolean;
   public readonly createdAt: Date;
 
   constructor(data: ClientInvocationData) {
     this.id = data.id;
     this.entityId = data.entityId;
     this.recordId = data.recordId;
-    this.success = data.success;
     this.createdAt = data.createdAt;
   }
 }
@@ -200,7 +197,6 @@ export class Client implements ClientData {
     tx: PoolClient,
     data: {
       id: string;
-      success: boolean;
       createdAt: Date;
     }
   ): Promise<ClientInvocation> {
@@ -212,19 +208,17 @@ export class Client implements ClientData {
         invocation_id,
         entity_id,
         record_id,
-        created_at,
-        success
+        created_at
       )
       VALUES
-        ($1, $2, $3, $4, $5, $6)
+        ($1, $2, $3, $4)
       RETURNING
         invocation_id AS id,
         entity_id,
         record_id,
-        created_at,
-        success
+        created_at
       `,
-      [data.id, this.id, this.recordId, data.createdAt, data.success]
+      [data.id, this.id, this.recordId, data.createdAt]
     );
 
     if (result.rows.length !== 1) {
@@ -237,7 +231,6 @@ export class Client implements ClientData {
       id: row.id,
       entityId: row.entity_id,
       recordId: row.record_id,
-      success: row.success,
       createdAt: row.created_at
     });
   }
@@ -249,8 +242,7 @@ export class Client implements ClientData {
         invocation_id as id,
         record_id,
         entity_id,
-        success,
-        created_at,
+        created_at
       FROM authx.authorization_invocation
       WHERE entity_id = $1
       ORDER BY created_at DESC

--- a/packages/authx/src/model/Client.ts
+++ b/packages/authx/src/model/Client.ts
@@ -4,6 +4,30 @@ import { Authorization } from "./Authorization";
 import { NotFoundError } from "../errors";
 import { ClientAction, createV2AuthXScope } from "../util/scopes";
 
+export interface ClientInvocationData {
+  readonly id: string;
+  readonly entityId: string;
+  readonly recordId: null | string;
+  readonly success: boolean;
+  readonly createdAt: Date;
+}
+
+export class ClientInvocation implements ClientInvocationData {
+  public readonly id: string;
+  public readonly entityId: string;
+  public readonly recordId: null | string;
+  public readonly success: boolean;
+  public readonly createdAt: Date;
+
+  constructor(data: ClientInvocationData) {
+    this.id = data.id;
+    this.entityId = data.entityId;
+    this.recordId = data.recordId;
+    this.success = data.success;
+    this.createdAt = data.createdAt;
+  }
+}
+
 export interface ClientRecordData {
   readonly id: string;
   readonly replacementRecordId: null | string;
@@ -168,6 +192,79 @@ export class Client implements ClientData {
           createdByAuthorizationId: row.created_by_authorization_id,
           createdAt: row.created_at,
           entityId: row.entity_id
+        })
+    );
+  }
+
+  public async invoke(
+    tx: PoolClient,
+    data: {
+      id: string;
+      success: boolean;
+      createdAt: Date;
+    }
+  ): Promise<ClientInvocation> {
+    // insert the new invocation
+    const result = await tx.query(
+      `
+      INSERT INTO authx.authorization_invocation
+      (
+        invocation_id,
+        entity_id,
+        record_id,
+        created_at,
+        success
+      )
+      VALUES
+        ($1, $2, $3, $4, $5, $6)
+      RETURNING
+        invocation_id AS id,
+        entity_id,
+        record_id,
+        created_at,
+        success
+      `,
+      [data.id, this.id, this.recordId, data.createdAt, data.success]
+    );
+
+    if (result.rows.length !== 1) {
+      throw new Error("INVARIANT: Insert must return exactly one row.");
+    }
+
+    const row = result.rows[0];
+
+    return new ClientInvocation({
+      id: row.id,
+      entityId: row.entity_id,
+      recordId: row.record_id,
+      success: row.success,
+      createdAt: row.created_at
+    });
+  }
+
+  public async invocations(tx: PoolClient): Promise<ClientInvocation[]> {
+    const result = await tx.query(
+      `
+      SELECT
+        invocation_id as id,
+        record_id,
+        entity_id,
+        success,
+        created_at,
+      FROM authx.authorization_invocation
+      WHERE entity_id = $1
+      ORDER BY created_at DESC
+      `,
+      [this.id]
+    );
+
+    return result.rows.map(
+      row =>
+        new ClientInvocation({
+          ...row,
+          recordId: row.record_id,
+          entityId: row.entity_id,
+          createdAt: row.created_at
         })
     );
   }

--- a/packages/authx/src/model/Client.ts
+++ b/packages/authx/src/model/Client.ts
@@ -15,6 +15,7 @@ export interface ClientData {
 
 export class Client implements ClientData {
   public readonly id: string;
+  public readonly recordId: string;
   public readonly enabled: boolean;
   public readonly name: string;
   public readonly description: string;
@@ -23,8 +24,9 @@ export class Client implements ClientData {
 
   private _grants: null | Promise<Grant[]> = null;
 
-  public constructor(data: ClientData) {
+  public constructor(data: ClientData & { readonly recordId: string }) {
     this.id = data.id;
+    this.recordId = data.recordId;
     this.enabled = data.enabled;
     this.name = data.name;
     this.description = data.description;
@@ -140,6 +142,7 @@ export class Client implements ClientData {
       `
       SELECT
         entity_id AS id,
+        record_id,
         enabled,
         name,
         description,
@@ -171,6 +174,7 @@ export class Client implements ClientData {
       row =>
         new Client({
           ...row,
+          recordId: row.record_id,
           secrets: row.secrets,
           urls: row.urls
         })
@@ -236,6 +240,7 @@ export class Client implements ClientData {
         ($1, $2, $3, $4, $5, $6, $7, $8, $9)
       RETURNING
         entity_id AS id,
+        record_id,
         enabled,
         name,
         description,
@@ -262,6 +267,7 @@ export class Client implements ClientData {
     const row = next.rows[0];
     return new Client({
       ...row,
+      recordId: row.record_id,
       secrets: row.secrets,
       urls: row.urls
     });

--- a/packages/authx/src/model/Credential.ts
+++ b/packages/authx/src/model/Credential.ts
@@ -5,6 +5,30 @@ import { Authorization } from "./Authorization";
 import { NotFoundError } from "../errors";
 import { CredentialAction, createV2AuthXScope } from "../util/scopes";
 
+export interface CredentialRecordData {
+  readonly id: string;
+  readonly replacementRecordId: null | string;
+  readonly entityId: string;
+  readonly createdAt: Date;
+  readonly createdByAuthorizationId: string;
+}
+
+export class CredentialRecord implements CredentialRecordData {
+  public readonly id: string;
+  public readonly replacementRecordId: null | string;
+  public readonly entityId: string;
+  public readonly createdAt: Date;
+  public readonly createdByAuthorizationId: string;
+
+  constructor(data: CredentialRecordData) {
+    this.id = data.id;
+    this.replacementRecordId = data.replacementRecordId;
+    this.entityId = data.entityId;
+    this.createdAt = data.createdAt;
+    this.createdByAuthorizationId = data.createdByAuthorizationId;
+  }
+}
+
 export interface CredentialData<C> {
   readonly id: string;
   readonly enabled: boolean;
@@ -84,6 +108,35 @@ export abstract class Credential<C> implements CredentialData<C> {
     }
 
     return (this._user = User.read(tx, this.userId));
+  }
+
+  public async records(tx: PoolClient): Promise<CredentialRecord[]> {
+    const result = await tx.query(
+      `
+      SELECT
+        record_id as id,
+        replacement_record_id,
+        entity_id,
+        created_by_authorization_id,
+        created_by_credential_id,
+        created_at,
+      FROM authx.authorization_record
+      WHERE entity_id = $1
+      ORDER BY created_at DESC
+      `,
+      [this.id]
+    );
+
+    return result.rows.map(
+      row =>
+        new CredentialRecord({
+          ...row,
+          replacementRecordId: row.replacement_record_id,
+          createdByAuthorizationId: row.created_by_authorization_id,
+          createdAt: row.created_at,
+          entityId: row.entity_id
+        })
+    );
   }
 
   public static read<T extends Credential<any>>(

--- a/packages/authx/src/model/Credential.ts
+++ b/packages/authx/src/model/Credential.ts
@@ -9,7 +9,6 @@ export interface CredentialInvocationData {
   readonly id: string;
   readonly entityId: string;
   readonly recordId: null | string;
-  readonly success: boolean;
   readonly createdAt: Date;
 }
 
@@ -17,14 +16,12 @@ export class CredentialInvocation implements CredentialInvocationData {
   public readonly id: string;
   public readonly entityId: string;
   public readonly recordId: null | string;
-  public readonly success: boolean;
   public readonly createdAt: Date;
 
   constructor(data: CredentialInvocationData) {
     this.id = data.id;
     this.entityId = data.entityId;
     this.recordId = data.recordId;
-    this.success = data.success;
     this.createdAt = data.createdAt;
   }
 }
@@ -167,7 +164,6 @@ export abstract class Credential<C> implements CredentialData<C> {
     tx: PoolClient,
     data: {
       id: string;
-      success: boolean;
       createdAt: Date;
     }
   ): Promise<CredentialInvocation> {
@@ -179,19 +175,17 @@ export abstract class Credential<C> implements CredentialData<C> {
         invocation_id,
         entity_id,
         record_id,
-        created_at,
-        success
+        created_at
       )
       VALUES
-        ($1, $2, $3, $4, $5, $6)
+        ($1, $2, $3, $4)
       RETURNING
         invocation_id AS id,
         entity_id,
         record_id,
-        created_at,
-        success
+        created_at
       `,
-      [data.id, this.id, this.recordId, data.createdAt, data.success]
+      [data.id, this.id, this.recordId, data.createdAt]
     );
 
     if (result.rows.length !== 1) {
@@ -204,7 +198,6 @@ export abstract class Credential<C> implements CredentialData<C> {
       id: row.id,
       entityId: row.entity_id,
       recordId: row.record_id,
-      success: row.success,
       createdAt: row.created_at
     });
   }
@@ -216,8 +209,7 @@ export abstract class Credential<C> implements CredentialData<C> {
         invocation_id as id,
         record_id,
         entity_id,
-        success,
-        created_at,
+        created_at
       FROM authx.authorization_invocation
       WHERE entity_id = $1
       ORDER BY created_at DESC

--- a/packages/authx/src/model/Credential.ts
+++ b/packages/authx/src/model/Credential.ts
@@ -16,6 +16,7 @@ export interface CredentialData<C> {
 
 export abstract class Credential<C> implements CredentialData<C> {
   public readonly id: string;
+  public readonly recordId: string;
   public readonly enabled: boolean;
   public readonly authorityId: string;
   public readonly authorityUserId: string;
@@ -24,8 +25,9 @@ export abstract class Credential<C> implements CredentialData<C> {
 
   private _user: null | Promise<User> = null;
 
-  public constructor(data: CredentialData<C>) {
+  public constructor(data: CredentialData<C> & { readonly recordId: string }) {
     this.id = data.id;
+    this.recordId = data.recordId;
     this.enabled = data.enabled;
     this.authorityId = data.authorityId;
     this.authorityUserId = data.authorityUserId;
@@ -154,6 +156,7 @@ export abstract class Credential<C> implements CredentialData<C> {
       `
       SELECT
         authx.credential_record.entity_id AS id,
+        authx.credential_record.record_id,
         authx.credential_record.enabled,
         authx.credential_record.authority_id,
         authx.credential_record.authority_user_id,
@@ -273,6 +276,7 @@ export abstract class Credential<C> implements CredentialData<C> {
         ($1, $2, $3, $4, $5, $6, $7, $8, $9)
       RETURNING
         entity_id AS id,
+        record_id,
         enabled,
         authority_id,
         authority_user_id,
@@ -299,6 +303,7 @@ export abstract class Credential<C> implements CredentialData<C> {
     const row = next.rows[0];
     return new this({
       ...row,
+      recordId: row.record_id,
       authorityId: row.authority_id,
       authorityUserId: row.authority_user_id,
       userId: row.user_id

--- a/packages/authx/src/model/Credential.ts
+++ b/packages/authx/src/model/Credential.ts
@@ -5,6 +5,30 @@ import { Authorization } from "./Authorization";
 import { NotFoundError } from "../errors";
 import { CredentialAction, createV2AuthXScope } from "../util/scopes";
 
+export interface CredentialInvocationData {
+  readonly id: string;
+  readonly entityId: string;
+  readonly recordId: null | string;
+  readonly success: boolean;
+  readonly createdAt: Date;
+}
+
+export class CredentialInvocation implements CredentialInvocationData {
+  public readonly id: string;
+  public readonly entityId: string;
+  public readonly recordId: null | string;
+  public readonly success: boolean;
+  public readonly createdAt: Date;
+
+  constructor(data: CredentialInvocationData) {
+    this.id = data.id;
+    this.entityId = data.entityId;
+    this.recordId = data.recordId;
+    this.success = data.success;
+    this.createdAt = data.createdAt;
+  }
+}
+
 export interface CredentialRecordData {
   readonly id: string;
   readonly replacementRecordId: null | string;
@@ -135,6 +159,79 @@ export abstract class Credential<C> implements CredentialData<C> {
           createdByAuthorizationId: row.created_by_authorization_id,
           createdAt: row.created_at,
           entityId: row.entity_id
+        })
+    );
+  }
+
+  public async invoke(
+    tx: PoolClient,
+    data: {
+      id: string;
+      success: boolean;
+      createdAt: Date;
+    }
+  ): Promise<CredentialInvocation> {
+    // insert the new invocation
+    const result = await tx.query(
+      `
+      INSERT INTO authx.authorization_invocation
+      (
+        invocation_id,
+        entity_id,
+        record_id,
+        created_at,
+        success
+      )
+      VALUES
+        ($1, $2, $3, $4, $5, $6)
+      RETURNING
+        invocation_id AS id,
+        entity_id,
+        record_id,
+        created_at,
+        success
+      `,
+      [data.id, this.id, this.recordId, data.createdAt, data.success]
+    );
+
+    if (result.rows.length !== 1) {
+      throw new Error("INVARIANT: Insert must return exactly one row.");
+    }
+
+    const row = result.rows[0];
+
+    return new CredentialInvocation({
+      id: row.id,
+      entityId: row.entity_id,
+      recordId: row.record_id,
+      success: row.success,
+      createdAt: row.created_at
+    });
+  }
+
+  public async invocations(tx: PoolClient): Promise<CredentialInvocation[]> {
+    const result = await tx.query(
+      `
+      SELECT
+        invocation_id as id,
+        record_id,
+        entity_id,
+        success,
+        created_at,
+      FROM authx.authorization_invocation
+      WHERE entity_id = $1
+      ORDER BY created_at DESC
+      `,
+      [this.id]
+    );
+
+    return result.rows.map(
+      row =>
+        new CredentialInvocation({
+          ...row,
+          recordId: row.record_id,
+          entityId: row.entity_id,
+          createdAt: row.created_at
         })
     );
   }

--- a/packages/authx/src/model/Credential.ts
+++ b/packages/authx/src/model/Credential.ts
@@ -229,14 +229,14 @@ export abstract class Credential<C> implements CredentialData<C> {
   }
 
   public static read<T extends Credential<any>>(
-    this: new (data: CredentialData<any>) => T,
+    this: new (data: CredentialData<any> & { readonly recordId: string }) => T,
     tx: PoolClient,
     id: string,
     options?: { forUpdate: boolean }
   ): Promise<T>;
 
   public static read<T extends Credential<any>>(
-    this: new (data: CredentialData<any>) => T,
+    this: new (data: CredentialData<any> & { readonly recordId: string }) => T,
     tx: PoolClient,
     id: string[],
     options?: { forUpdate: boolean }
@@ -244,7 +244,11 @@ export abstract class Credential<C> implements CredentialData<C> {
 
   public static read<
     M extends {
-      [key: string]: { new (data: CredentialData<any>): Credential<any> };
+      [key: string]: {
+        new (
+          data: CredentialData<any> & { readonly recordId: string }
+        ): Credential<any>;
+      };
     },
     K extends keyof M
   >(
@@ -256,7 +260,11 @@ export abstract class Credential<C> implements CredentialData<C> {
 
   public static read<
     M extends {
-      [key: string]: { new (data: CredentialData<any>): Credential<any> };
+      [key: string]: {
+        new (
+          data: CredentialData<any> & { readonly recordId: string }
+        ): Credential<any>;
+      };
     },
     K extends keyof M
   >(
@@ -274,7 +282,7 @@ export abstract class Credential<C> implements CredentialData<C> {
     K extends keyof M
   >(
     this: {
-      new (data: CredentialData<any>): T;
+      new (data: CredentialData<any> & { readonly recordId: string }): T;
     },
     tx: PoolClient,
     id: string[] | string,
@@ -358,7 +366,7 @@ export abstract class Credential<C> implements CredentialData<C> {
 
   public static async write<T extends Credential<any>>(
     this: {
-      new (data: CredentialData<any>): T;
+      new (data: CredentialData<any> & { readonly recordId: string }): T;
     },
     tx: PoolClient,
     data: CredentialData<any>,

--- a/packages/authx/src/model/Grant.ts
+++ b/packages/authx/src/model/Grant.ts
@@ -10,7 +10,6 @@ export interface GrantInvocationData {
   readonly id: string;
   readonly entityId: string;
   readonly recordId: null | string;
-  readonly success: boolean;
   readonly createdAt: Date;
 }
 
@@ -18,14 +17,12 @@ export class GrantInvocation implements GrantInvocationData {
   public readonly id: string;
   public readonly entityId: string;
   public readonly recordId: null | string;
-  public readonly success: boolean;
   public readonly createdAt: Date;
 
   constructor(data: GrantInvocationData) {
     this.id = data.id;
     this.entityId = data.entityId;
     this.recordId = data.recordId;
-    this.success = data.success;
     this.createdAt = data.createdAt;
   }
 }
@@ -232,7 +229,6 @@ export class Grant implements GrantData {
     tx: PoolClient,
     data: {
       id: string;
-      success: boolean;
       createdAt: Date;
     }
   ): Promise<GrantInvocation> {
@@ -244,19 +240,17 @@ export class Grant implements GrantData {
         invocation_id,
         entity_id,
         record_id,
-        created_at,
-        success
+        created_at
       )
       VALUES
-        ($1, $2, $3, $4, $5, $6)
+        ($1, $2, $3, $4)
       RETURNING
         invocation_id AS id,
         entity_id,
         record_id,
-        created_at,
-        success
+        created_at
       `,
-      [data.id, this.id, this.recordId, data.createdAt, data.success]
+      [data.id, this.id, this.recordId, data.createdAt]
     );
 
     if (result.rows.length !== 1) {
@@ -269,7 +263,6 @@ export class Grant implements GrantData {
       id: row.id,
       entityId: row.entity_id,
       recordId: row.record_id,
-      success: row.success,
       createdAt: row.created_at
     });
   }
@@ -281,8 +274,7 @@ export class Grant implements GrantData {
         invocation_id as id,
         record_id,
         entity_id,
-        success,
-        created_at,
+        created_at
       FROM authx.authorization_invocation
       WHERE entity_id = $1
       ORDER BY created_at DESC

--- a/packages/authx/src/model/Grant.ts
+++ b/packages/authx/src/model/Grant.ts
@@ -18,6 +18,7 @@ export interface GrantData {
 
 export class Grant implements GrantData {
   public readonly id: string;
+  public readonly recordId: string;
   public readonly enabled: boolean;
   public readonly clientId: string;
   public readonly userId: string;
@@ -29,8 +30,9 @@ export class Grant implements GrantData {
   private _user: null | Promise<User> = null;
   private _authorizations: null | Promise<Authorization[]> = null;
 
-  public constructor(data: GrantData) {
+  public constructor(data: GrantData & { readonly recordId: string }) {
     this.id = data.id;
+    this.recordId = data.recordId;
     this.enabled = data.enabled;
     this.clientId = data.clientId;
     this.userId = data.userId;
@@ -172,6 +174,7 @@ export class Grant implements GrantData {
       `
       SELECT
         entity_id AS id,
+        record_id,
         enabled,
         client_id,
         user_id,
@@ -201,6 +204,7 @@ export class Grant implements GrantData {
       row =>
         new Grant({
           ...row,
+          recordId: row.record_id,
           clientId: row.client_id,
           userId: row.user_id
         })
@@ -269,6 +273,7 @@ export class Grant implements GrantData {
         ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
       RETURNING
         entity_id AS id,
+        record_id,
         enabled,
         client_id,
         user_id,
@@ -297,6 +302,7 @@ export class Grant implements GrantData {
     const row = next.rows[0];
     return new Grant({
       ...row,
+      recordId: row.record_id,
       clientId: row.client_id,
       userId: row.user_id
     });

--- a/packages/authx/src/model/Grant.ts
+++ b/packages/authx/src/model/Grant.ts
@@ -6,6 +6,30 @@ import { simplify, getIntersection, isSuperset } from "@authx/scopes";
 import { NotFoundError } from "../errors";
 import { GrantAction, createV2AuthXScope } from "../util/scopes";
 
+export interface GrantRecordData {
+  readonly id: string;
+  readonly replacementRecordId: null | string;
+  readonly entityId: string;
+  readonly createdAt: Date;
+  readonly createdByAuthorizationId: string;
+}
+
+export class GrantRecord implements GrantRecordData {
+  public readonly id: string;
+  public readonly replacementRecordId: null | string;
+  public readonly entityId: string;
+  public readonly createdAt: Date;
+  public readonly createdByAuthorizationId: string;
+
+  constructor(data: GrantRecordData) {
+    this.id = data.id;
+    this.replacementRecordId = data.replacementRecordId;
+    this.entityId = data.entityId;
+    this.createdAt = data.createdAt;
+    this.createdByAuthorizationId = data.createdByAuthorizationId;
+  }
+}
+
 export interface GrantData {
   readonly id: string;
   readonly enabled: boolean;
@@ -149,6 +173,35 @@ export class Grant implements GrantData {
     refresh: boolean = false
   ): Promise<boolean> {
     return isSuperset(await this.access(tx, values, refresh), scope);
+  }
+
+  public async records(tx: PoolClient): Promise<GrantRecord[]> {
+    const result = await tx.query(
+      `
+      SELECT
+        record_id as id,
+        replacement_record_id,
+        entity_id,
+        created_by_authorization_id,
+        created_by_credential_id,
+        created_at,
+      FROM authx.authorization_record
+      WHERE entity_id = $1
+      ORDER BY created_at DESC
+      `,
+      [this.id]
+    );
+
+    return result.rows.map(
+      row =>
+        new GrantRecord({
+          ...row,
+          replacementRecordId: row.replacement_record_id,
+          createdByAuthorizationId: row.created_by_authorization_id,
+          createdAt: row.created_at,
+          entityId: row.entity_id
+        })
+    );
   }
 
   public static read(

--- a/packages/authx/src/model/Grant.ts
+++ b/packages/authx/src/model/Grant.ts
@@ -6,6 +6,30 @@ import { simplify, getIntersection, isSuperset } from "@authx/scopes";
 import { NotFoundError } from "../errors";
 import { GrantAction, createV2AuthXScope } from "../util/scopes";
 
+export interface GrantInvocationData {
+  readonly id: string;
+  readonly entityId: string;
+  readonly recordId: null | string;
+  readonly success: boolean;
+  readonly createdAt: Date;
+}
+
+export class GrantInvocation implements GrantInvocationData {
+  public readonly id: string;
+  public readonly entityId: string;
+  public readonly recordId: null | string;
+  public readonly success: boolean;
+  public readonly createdAt: Date;
+
+  constructor(data: GrantInvocationData) {
+    this.id = data.id;
+    this.entityId = data.entityId;
+    this.recordId = data.recordId;
+    this.success = data.success;
+    this.createdAt = data.createdAt;
+  }
+}
+
 export interface GrantRecordData {
   readonly id: string;
   readonly replacementRecordId: null | string;
@@ -200,6 +224,79 @@ export class Grant implements GrantData {
           createdByAuthorizationId: row.created_by_authorization_id,
           createdAt: row.created_at,
           entityId: row.entity_id
+        })
+    );
+  }
+
+  public async invoke(
+    tx: PoolClient,
+    data: {
+      id: string;
+      success: boolean;
+      createdAt: Date;
+    }
+  ): Promise<GrantInvocation> {
+    // insert the new invocation
+    const result = await tx.query(
+      `
+      INSERT INTO authx.authorization_invocation
+      (
+        invocation_id,
+        entity_id,
+        record_id,
+        created_at,
+        success
+      )
+      VALUES
+        ($1, $2, $3, $4, $5, $6)
+      RETURNING
+        invocation_id AS id,
+        entity_id,
+        record_id,
+        created_at,
+        success
+      `,
+      [data.id, this.id, this.recordId, data.createdAt, data.success]
+    );
+
+    if (result.rows.length !== 1) {
+      throw new Error("INVARIANT: Insert must return exactly one row.");
+    }
+
+    const row = result.rows[0];
+
+    return new GrantInvocation({
+      id: row.id,
+      entityId: row.entity_id,
+      recordId: row.record_id,
+      success: row.success,
+      createdAt: row.created_at
+    });
+  }
+
+  public async invocations(tx: PoolClient): Promise<GrantInvocation[]> {
+    const result = await tx.query(
+      `
+      SELECT
+        invocation_id as id,
+        record_id,
+        entity_id,
+        success,
+        created_at,
+      FROM authx.authorization_invocation
+      WHERE entity_id = $1
+      ORDER BY created_at DESC
+      `,
+      [this.id]
+    );
+
+    return result.rows.map(
+      row =>
+        new GrantInvocation({
+          ...row,
+          recordId: row.record_id,
+          entityId: row.entity_id,
+          createdAt: row.created_at
         })
     );
   }

--- a/packages/authx/src/model/Role.ts
+++ b/packages/authx/src/model/Role.ts
@@ -5,6 +5,30 @@ import { simplify, isSuperset, inject } from "@authx/scopes";
 import { NotFoundError } from "../errors";
 import { RoleAction, createV2AuthXScope } from "../util/scopes";
 
+export interface RoleInvocationData {
+  readonly id: string;
+  readonly entityId: string;
+  readonly recordId: null | string;
+  readonly success: boolean;
+  readonly createdAt: Date;
+}
+
+export class RoleInvocation implements RoleInvocationData {
+  public readonly id: string;
+  public readonly entityId: string;
+  public readonly recordId: null | string;
+  public readonly success: boolean;
+  public readonly createdAt: Date;
+
+  constructor(data: RoleInvocationData) {
+    this.id = data.id;
+    this.entityId = data.entityId;
+    this.recordId = data.recordId;
+    this.success = data.success;
+    this.createdAt = data.createdAt;
+  }
+}
+
 export interface RoleRecordData {
   readonly id: string;
   readonly replacementRecordId: null | string;
@@ -157,6 +181,79 @@ export class Role implements RoleData {
           createdByAuthorizationId: row.created_by_authorization_id,
           createdAt: row.created_at,
           entityId: row.entity_id
+        })
+    );
+  }
+
+  public async invoke(
+    tx: PoolClient,
+    data: {
+      id: string;
+      success: boolean;
+      createdAt: Date;
+    }
+  ): Promise<RoleInvocation> {
+    // insert the new invocation
+    const result = await tx.query(
+      `
+      INSERT INTO authx.authorization_invocation
+      (
+        invocation_id,
+        entity_id,
+        record_id,
+        created_at,
+        success
+      )
+      VALUES
+        ($1, $2, $3, $4, $5, $6)
+      RETURNING
+        invocation_id AS id,
+        entity_id,
+        record_id,
+        created_at,
+        success
+      `,
+      [data.id, this.id, this.recordId, data.createdAt, data.success]
+    );
+
+    if (result.rows.length !== 1) {
+      throw new Error("INVARIANT: Insert must return exactly one row.");
+    }
+
+    const row = result.rows[0];
+
+    return new RoleInvocation({
+      id: row.id,
+      entityId: row.entity_id,
+      recordId: row.record_id,
+      success: row.success,
+      createdAt: row.created_at
+    });
+  }
+
+  public async invocations(tx: PoolClient): Promise<RoleInvocation[]> {
+    const result = await tx.query(
+      `
+      SELECT
+        invocation_id as id,
+        record_id,
+        entity_id,
+        success,
+        created_at,
+      FROM authx.authorization_invocation
+      WHERE entity_id = $1
+      ORDER BY created_at DESC
+      `,
+      [this.id]
+    );
+
+    return result.rows.map(
+      row =>
+        new RoleInvocation({
+          ...row,
+          recordId: row.record_id,
+          entityId: row.entity_id,
+          createdAt: row.created_at
         })
     );
   }

--- a/packages/authx/src/model/Role.ts
+++ b/packages/authx/src/model/Role.ts
@@ -5,30 +5,6 @@ import { simplify, isSuperset, inject } from "@authx/scopes";
 import { NotFoundError } from "../errors";
 import { RoleAction, createV2AuthXScope } from "../util/scopes";
 
-export interface RoleInvocationData {
-  readonly id: string;
-  readonly entityId: string;
-  readonly recordId: null | string;
-  readonly success: boolean;
-  readonly createdAt: Date;
-}
-
-export class RoleInvocation implements RoleInvocationData {
-  public readonly id: string;
-  public readonly entityId: string;
-  public readonly recordId: null | string;
-  public readonly success: boolean;
-  public readonly createdAt: Date;
-
-  constructor(data: RoleInvocationData) {
-    this.id = data.id;
-    this.entityId = data.entityId;
-    this.recordId = data.recordId;
-    this.success = data.success;
-    this.createdAt = data.createdAt;
-  }
-}
-
 export interface RoleRecordData {
   readonly id: string;
   readonly replacementRecordId: null | string;
@@ -181,79 +157,6 @@ export class Role implements RoleData {
           createdByAuthorizationId: row.created_by_authorization_id,
           createdAt: row.created_at,
           entityId: row.entity_id
-        })
-    );
-  }
-
-  public async invoke(
-    tx: PoolClient,
-    data: {
-      id: string;
-      success: boolean;
-      createdAt: Date;
-    }
-  ): Promise<RoleInvocation> {
-    // insert the new invocation
-    const result = await tx.query(
-      `
-      INSERT INTO authx.authorization_invocation
-      (
-        invocation_id,
-        entity_id,
-        record_id,
-        created_at,
-        success
-      )
-      VALUES
-        ($1, $2, $3, $4, $5, $6)
-      RETURNING
-        invocation_id AS id,
-        entity_id,
-        record_id,
-        created_at,
-        success
-      `,
-      [data.id, this.id, this.recordId, data.createdAt, data.success]
-    );
-
-    if (result.rows.length !== 1) {
-      throw new Error("INVARIANT: Insert must return exactly one row.");
-    }
-
-    const row = result.rows[0];
-
-    return new RoleInvocation({
-      id: row.id,
-      entityId: row.entity_id,
-      recordId: row.record_id,
-      success: row.success,
-      createdAt: row.created_at
-    });
-  }
-
-  public async invocations(tx: PoolClient): Promise<RoleInvocation[]> {
-    const result = await tx.query(
-      `
-      SELECT
-        invocation_id as id,
-        record_id,
-        entity_id,
-        success,
-        created_at,
-      FROM authx.authorization_invocation
-      WHERE entity_id = $1
-      ORDER BY created_at DESC
-      `,
-      [this.id]
-    );
-
-    return result.rows.map(
-      row =>
-        new RoleInvocation({
-          ...row,
-          recordId: row.record_id,
-          entityId: row.entity_id,
-          createdAt: row.created_at
         })
     );
   }

--- a/packages/authx/src/model/Role.ts
+++ b/packages/authx/src/model/Role.ts
@@ -16,6 +16,7 @@ export interface RoleData {
 
 export class Role implements RoleData {
   public readonly id: string;
+  public readonly recordId: string;
   public readonly enabled: boolean;
   public readonly name: string;
   public readonly description: string;
@@ -24,8 +25,9 @@ export class Role implements RoleData {
 
   private _users: null | Promise<User[]> = null;
 
-  public constructor(data: RoleData) {
+  public constructor(data: RoleData & { readonly recordId: string }) {
     this.id = data.id;
+    this.recordId = data.recordId;
     this.enabled = data.enabled;
     this.name = data.name;
     this.description = data.description;
@@ -168,6 +170,7 @@ export class Role implements RoleData {
       row =>
         new Role({
           ...row,
+          recordId: row.record_id,
           userIds: row.user_ids.filter((id: null | string) => id)
         })
     );
@@ -252,6 +255,8 @@ export class Role implements RoleData {
       throw new Error("INVARIANT: Insert must return exactly one row.");
     }
 
+    const row = next.rows[0];
+
     // insert the new record's users
     const userIds = [...new Set(data.userIds)];
     const users = await tx.query(
@@ -271,7 +276,8 @@ export class Role implements RoleData {
     }
 
     return new Role({
-      ...next.rows[0],
+      ...row,
+      recordId: row.record_id,
       userIds: users.rows.map(({ user_id: userId }) => userId)
     });
   }

--- a/packages/authx/src/model/User.ts
+++ b/packages/authx/src/model/User.ts
@@ -7,6 +7,30 @@ import { Authorization } from "./Authorization";
 import { NotFoundError } from "../errors";
 import { UserAction, createV2AuthXScope } from "../util/scopes";
 
+export interface UserInvocationData {
+  readonly id: string;
+  readonly entityId: string;
+  readonly recordId: null | string;
+  readonly success: boolean;
+  readonly createdAt: Date;
+}
+
+export class UserInvocation implements UserInvocationData {
+  public readonly id: string;
+  public readonly entityId: string;
+  public readonly recordId: null | string;
+  public readonly success: boolean;
+  public readonly createdAt: Date;
+
+  constructor(data: UserInvocationData) {
+    this.id = data.id;
+    this.entityId = data.entityId;
+    this.recordId = data.recordId;
+    this.success = data.success;
+    this.createdAt = data.createdAt;
+  }
+}
+
 export interface UserRecordData {
   readonly id: string;
   readonly replacementRecordId: null | string;
@@ -290,6 +314,79 @@ export class User implements UserData {
           createdByAuthorizationId: row.created_by_authorization_id,
           createdAt: row.created_at,
           entityId: row.entity_id
+        })
+    );
+  }
+
+  public async invoke(
+    tx: PoolClient,
+    data: {
+      id: string;
+      success: boolean;
+      createdAt: Date;
+    }
+  ): Promise<UserInvocation> {
+    // insert the new invocation
+    const result = await tx.query(
+      `
+      INSERT INTO authx.authorization_invocation
+      (
+        invocation_id,
+        entity_id,
+        record_id,
+        created_at,
+        success
+      )
+      VALUES
+        ($1, $2, $3, $4, $5, $6)
+      RETURNING
+        invocation_id AS id,
+        entity_id,
+        record_id,
+        created_at,
+        success
+      `,
+      [data.id, this.id, this.recordId, data.createdAt, data.success]
+    );
+
+    if (result.rows.length !== 1) {
+      throw new Error("INVARIANT: Insert must return exactly one row.");
+    }
+
+    const row = result.rows[0];
+
+    return new UserInvocation({
+      id: row.id,
+      entityId: row.entity_id,
+      recordId: row.record_id,
+      success: row.success,
+      createdAt: row.created_at
+    });
+  }
+
+  public async invocations(tx: PoolClient): Promise<UserInvocation[]> {
+    const result = await tx.query(
+      `
+      SELECT
+        invocation_id as id,
+        record_id,
+        entity_id,
+        success,
+        created_at,
+      FROM authx.authorization_invocation
+      WHERE entity_id = $1
+      ORDER BY created_at DESC
+      `,
+      [this.id]
+    );
+
+    return result.rows.map(
+      row =>
+        new UserInvocation({
+          ...row,
+          recordId: row.record_id,
+          entityId: row.entity_id,
+          createdAt: row.created_at
         })
     );
   }

--- a/packages/authx/src/model/User.ts
+++ b/packages/authx/src/model/User.ts
@@ -7,30 +7,6 @@ import { Authorization } from "./Authorization";
 import { NotFoundError } from "../errors";
 import { UserAction, createV2AuthXScope } from "../util/scopes";
 
-export interface UserInvocationData {
-  readonly id: string;
-  readonly entityId: string;
-  readonly recordId: null | string;
-  readonly success: boolean;
-  readonly createdAt: Date;
-}
-
-export class UserInvocation implements UserInvocationData {
-  public readonly id: string;
-  public readonly entityId: string;
-  public readonly recordId: null | string;
-  public readonly success: boolean;
-  public readonly createdAt: Date;
-
-  constructor(data: UserInvocationData) {
-    this.id = data.id;
-    this.entityId = data.entityId;
-    this.recordId = data.recordId;
-    this.success = data.success;
-    this.createdAt = data.createdAt;
-  }
-}
-
 export interface UserRecordData {
   readonly id: string;
   readonly replacementRecordId: null | string;
@@ -314,79 +290,6 @@ export class User implements UserData {
           createdByAuthorizationId: row.created_by_authorization_id,
           createdAt: row.created_at,
           entityId: row.entity_id
-        })
-    );
-  }
-
-  public async invoke(
-    tx: PoolClient,
-    data: {
-      id: string;
-      success: boolean;
-      createdAt: Date;
-    }
-  ): Promise<UserInvocation> {
-    // insert the new invocation
-    const result = await tx.query(
-      `
-      INSERT INTO authx.authorization_invocation
-      (
-        invocation_id,
-        entity_id,
-        record_id,
-        created_at,
-        success
-      )
-      VALUES
-        ($1, $2, $3, $4, $5, $6)
-      RETURNING
-        invocation_id AS id,
-        entity_id,
-        record_id,
-        created_at,
-        success
-      `,
-      [data.id, this.id, this.recordId, data.createdAt, data.success]
-    );
-
-    if (result.rows.length !== 1) {
-      throw new Error("INVARIANT: Insert must return exactly one row.");
-    }
-
-    const row = result.rows[0];
-
-    return new UserInvocation({
-      id: row.id,
-      entityId: row.entity_id,
-      recordId: row.record_id,
-      success: row.success,
-      createdAt: row.created_at
-    });
-  }
-
-  public async invocations(tx: PoolClient): Promise<UserInvocation[]> {
-    const result = await tx.query(
-      `
-      SELECT
-        invocation_id as id,
-        record_id,
-        entity_id,
-        success,
-        created_at,
-      FROM authx.authorization_invocation
-      WHERE entity_id = $1
-      ORDER BY created_at DESC
-      `,
-      [this.id]
-    );
-
-    return result.rows.map(
-      row =>
-        new UserInvocation({
-          ...row,
-          recordId: row.record_id,
-          entityId: row.entity_id,
-          createdAt: row.created_at
         })
     );
   }

--- a/packages/authx/src/model/User.ts
+++ b/packages/authx/src/model/User.ts
@@ -18,6 +18,7 @@ export interface UserData {
 
 export class User implements UserData {
   public readonly id: string;
+  public readonly recordId: string;
   public readonly enabled: boolean;
   public readonly type: UserType;
   public readonly name: string;
@@ -27,8 +28,9 @@ export class User implements UserData {
   private _roles: null | Promise<Role[]> = null;
   private _grants: null | Promise<Grant[]> = null;
 
-  public constructor(data: UserData) {
+  public constructor(data: UserData & { readonly recordId: string }) {
     this.id = data.id;
+    this.recordId = data.recordId;
     this.enabled = data.enabled;
     this.type = data.type;
     this.name = data.name;
@@ -287,7 +289,8 @@ export class User implements UserData {
     const users = result.rows.map(
       row =>
         new User({
-          ...row
+          ...row,
+          recordId: row.record_id
         })
     );
 
@@ -370,8 +373,10 @@ export class User implements UserData {
       throw new Error("INVARIANT: Insert must return exactly one row.");
     }
 
+    const row = next.rows[0];
     return new User({
-      ...next.rows[0]
+      ...row,
+      recordId: row.record_id
     });
   }
 }

--- a/packages/authx/src/oauth2.ts
+++ b/packages/authx/src/oauth2.ts
@@ -374,6 +374,12 @@ async function oAuth2Middleware(
             );
           }
 
+          // Invoke the client.
+          await client.invoke(tx, {
+            id: v4(),
+            createdAt: new Date()
+          });
+
           // Decode and validate the authorization code.
           const [grantId, issuedAt, nonce] = Buffer.from(paramsCode, "base64")
             .toString("utf8")
@@ -428,6 +434,12 @@ async function oAuth2Middleware(
               paramsClientId
             );
           }
+
+          // Invoke the grant.
+          await grant.invoke(tx, {
+            id: v4(),
+            createdAt: new Date()
+          });
 
           // Fetch the user.
           const user = await grant.user(tx);
@@ -554,6 +566,13 @@ async function oAuth2Middleware(
             currentAuthorizationId: requestedAuthorization.id
           });
 
+          const tokenId = v4();
+          await requestedAuthorization.invoke(tx, {
+            id: tokenId,
+            format: "bearer",
+            createdAt: new Date()
+          });
+
           const body = {
             /* eslint-disable @typescript-eslint/camelcase */
             token_type: "bearer",
@@ -565,6 +584,7 @@ async function oAuth2Middleware(
               },
               privateKey,
               {
+                jwtid: tokenId,
                 algorithm: "RS512",
                 expiresIn: jwtValidityDuration,
                 audience: client.id,
@@ -664,6 +684,12 @@ async function oAuth2Middleware(
             );
           }
 
+          // Invoke the client.
+          await client.invoke(tx, {
+            id: v4(),
+            createdAt: new Date()
+          });
+
           // Decode and validate the authorization code.
           const [grantId, issuedAt, nonce] = Buffer.from(
             paramsRefreshToken,
@@ -712,6 +738,12 @@ async function oAuth2Middleware(
               paramsClientId
             );
           }
+
+          // Invoke the grant.
+          await grant.invoke(tx, {
+            id: v4(),
+            createdAt: new Date()
+          });
 
           // Fetch the user.
           const user = await grant.user(tx);
@@ -829,6 +861,13 @@ async function oAuth2Middleware(
             currentAuthorizationId: requestedAuthorization.id
           });
 
+          const tokenId = v4();
+          await requestedAuthorization.invoke(tx, {
+            id: tokenId,
+            format: "bearer",
+            createdAt: new Date()
+          });
+
           const body = {
             /* eslint-disable @typescript-eslint/camelcase */
             token_type: "bearer",
@@ -840,6 +879,7 @@ async function oAuth2Middleware(
               },
               privateKey,
               {
+                jwtid: tokenId,
                 algorithm: "RS512",
                 expiresIn: jwtValidityDuration,
                 audience: client.id,

--- a/packages/http-proxy-client/package.json
+++ b/packages/http-proxy-client/package.json
@@ -15,8 +15,8 @@
   },
   "description": "",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.11.0",
-    "@typescript-eslint/parser": "^2.11.0",
+    "@typescript-eslint/eslint-plugin": "^2.15.0",
+    "@typescript-eslint/parser": "^2.15.0",
     "ava": "^2.4.0",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",

--- a/packages/http-proxy-resource/package.json
+++ b/packages/http-proxy-resource/package.json
@@ -16,8 +16,8 @@
   },
   "description": "",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.11.0",
-    "@typescript-eslint/parser": "^2.11.0",
+    "@typescript-eslint/eslint-plugin": "^2.15.0",
+    "@typescript-eslint/parser": "^2.15.0",
     "ava": "^2.4.0",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",

--- a/packages/http-proxy-web/package.json
+++ b/packages/http-proxy-web/package.json
@@ -18,8 +18,8 @@
   },
   "description": "",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.11.0",
-    "@typescript-eslint/parser": "^2.11.0",
+    "@typescript-eslint/eslint-plugin": "^2.15.0",
+    "@typescript-eslint/parser": "^2.15.0",
     "ava": "^2.4.0",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -23,8 +23,8 @@
   },
   "description": "",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.11.0",
-    "@typescript-eslint/parser": "^2.11.0",
+    "@typescript-eslint/eslint-plugin": "^2.15.0",
+    "@typescript-eslint/parser": "^2.15.0",
     "ava": "^2.4.0",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -7,8 +7,8 @@
   "dependencies": {},
   "description": "",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.11.0",
-    "@typescript-eslint/parser": "^2.11.0",
+    "@typescript-eslint/eslint-plugin": "^2.15.0",
+    "@typescript-eslint/parser": "^2.15.0",
     "ava": "^2.4.0",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",

--- a/packages/scopes/package.json
+++ b/packages/scopes/package.json
@@ -7,8 +7,8 @@
   "dependencies": {},
   "description": "",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.11.0",
-    "@typescript-eslint/parser": "^2.11.0",
+    "@typescript-eslint/eslint-plugin": "^2.15.0",
+    "@typescript-eslint/parser": "^2.15.0",
     "ava": "^2.4.0",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",

--- a/packages/strategy-email/package.json
+++ b/packages/strategy-email/package.json
@@ -6,17 +6,17 @@
   "bugs": "https://github.com/the-control-group/authx/issues",
   "dependencies": {
     "@authx/scopes": "^3.0.0",
-    "@types/pg": "^7.14.0",
+    "@types/pg": "^7.14.1",
     "@types/uuid": "^3.4.6",
-    "graphql": "15.0.0-alpha.2",
+    "graphql": "15.0.0-rc.1",
     "pg": "^7.17.0",
     "uuid": "^3.3.3"
   },
   "description": "",
   "devDependencies": {
     "@authx/authx": "^2.0.0",
-    "@typescript-eslint/eslint-plugin": "^2.11.0",
-    "@typescript-eslint/parser": "^2.11.0",
+    "@typescript-eslint/eslint-plugin": "^2.15.0",
+    "@typescript-eslint/parser": "^2.15.0",
     "ava": "^2.4.0",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",
@@ -61,6 +61,6 @@
   "types": "dist/server/index.d.ts",
   "version": "1.0.0",
   "resolutions": {
-    "**/graphql": "15.0.0-alpha.2"
+    "**/graphql": "15.0.0-rc.1"
   }
 }

--- a/packages/strategy-email/src/server/graphql/mutation/authenticateEmail.ts
+++ b/packages/strategy-email/src/server/graphql/mutation/authenticateEmail.ts
@@ -169,6 +169,12 @@ export const authenticateEmail: GraphQLFieldConfig<
         );
       }
 
+      // Invoke the credential.
+      await credential.invoke(tx, {
+        id: v4(),
+        createdAt: new Date()
+      });
+
       const authorizationId = v4();
 
       const values = {
@@ -223,6 +229,14 @@ export const authenticateEmail: GraphQLFieldConfig<
           createdAt: new Date()
         }
       );
+
+      // Invoke the new authorization, since it will be used for the remainder
+      // of the request.
+      await authorization.invoke(tx, {
+        id: v4(),
+        format: "basic",
+        createdAt: new Date()
+      });
 
       await tx.query("COMMIT");
 

--- a/packages/strategy-openid/package.json
+++ b/packages/strategy-openid/package.json
@@ -6,17 +6,17 @@
   "bugs": "https://github.com/the-control-group/authx/issues",
   "dependencies": {
     "@authx/scopes": "^3.0.0",
-    "@types/pg": "^7.14.0",
+    "@types/pg": "^7.14.1",
     "@types/uuid": "^3.4.6",
-    "graphql": "15.0.0-alpha.2",
+    "graphql": "15.0.0-rc.1",
     "pg": "^7.17.0",
     "uuid": "^3.3.3"
   },
   "description": "",
   "devDependencies": {
     "@authx/authx": "^2.0.0",
-    "@typescript-eslint/eslint-plugin": "^2.11.0",
-    "@typescript-eslint/parser": "^2.11.0",
+    "@typescript-eslint/eslint-plugin": "^2.15.0",
+    "@typescript-eslint/parser": "^2.15.0",
     "ava": "^2.4.0",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",
@@ -62,6 +62,6 @@
   "types": "dist/server/index.d.ts",
   "version": "1.0.0",
   "resolutions": {
-    "**/graphql": "15.0.0-alpha.2"
+    "**/graphql": "15.0.0-rc.1"
   }
 }

--- a/packages/strategy-openid/src/server/graphql/mutation/authenticateOpenId.ts
+++ b/packages/strategy-openid/src/server/graphql/mutation/authenticateOpenId.ts
@@ -165,6 +165,12 @@ export const authenticateOpenId: GraphQLFieldConfig<
         );
       }
 
+      // Invoke the credential.
+      await credential.invoke(tx, {
+        id: v4(),
+        createdAt: new Date()
+      });
+
       const authorizationId = v4();
 
       // Get the credential
@@ -326,6 +332,14 @@ export const authenticateOpenId: GraphQLFieldConfig<
           createdAt: new Date()
         }
       );
+
+      // Invoke the new authorization, since it will be used for the remainder
+      // of the request.
+      await authorization.invoke(tx, {
+        id: v4(),
+        format: "basic",
+        createdAt: new Date()
+      });
 
       await tx.query("COMMIT");
 

--- a/packages/strategy-openid/src/server/graphql/mutation/authenticateOpenId.ts
+++ b/packages/strategy-openid/src/server/graphql/mutation/authenticateOpenId.ts
@@ -165,12 +165,6 @@ export const authenticateOpenId: GraphQLFieldConfig<
         );
       }
 
-      // Invoke the credential.
-      await credential.invoke(tx, {
-        id: v4(),
-        createdAt: new Date()
-      });
-
       const authorizationId = v4();
 
       // Get the credential
@@ -279,6 +273,12 @@ export const authenticateOpenId: GraphQLFieldConfig<
       if (!credential) {
         throw new AuthenticationError("No such credential exists.");
       }
+
+      // Invoke the credential.
+      await credential.invoke(tx, {
+        id: v4(),
+        createdAt: new Date()
+      });
 
       const values = {
         currentAuthorizationId: authorizationId,

--- a/packages/strategy-password/package.json
+++ b/packages/strategy-password/package.json
@@ -7,18 +7,18 @@
   "dependencies": {
     "@authx/scopes": "^3.0.0",
     "@types/bcrypt": "^3.0.0",
-    "@types/pg": "^7.14.0",
+    "@types/pg": "^7.14.1",
     "@types/uuid": "^3.4.6",
     "bcrypt": "^3.0.7",
-    "graphql": "15.0.0-alpha.2",
+    "graphql": "15.0.0-rc.1",
     "pg": "^7.17.0",
     "uuid": "^3.3.3"
   },
   "description": "",
   "devDependencies": {
     "@authx/authx": "^2.0.0",
-    "@typescript-eslint/eslint-plugin": "^2.11.0",
-    "@typescript-eslint/parser": "^2.11.0",
+    "@typescript-eslint/eslint-plugin": "^2.15.0",
+    "@typescript-eslint/parser": "^2.15.0",
     "ava": "^2.4.0",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",
@@ -63,6 +63,6 @@
   "types": "dist/server/index.d.ts",
   "version": "1.0.1",
   "resolutions": {
-    "**/graphql": "15.0.0-alpha.2"
+    "**/graphql": "15.0.0-rc.1"
   }
 }

--- a/packages/strategy-password/src/server/graphql/mutation/authenticatePassword.ts
+++ b/packages/strategy-password/src/server/graphql/mutation/authenticatePassword.ts
@@ -131,6 +131,12 @@ export const authenticatePassword: GraphQLFieldConfig<
         );
       }
 
+      // Invoke the credential.
+      await credential.invoke(tx, {
+        id: v4(),
+        createdAt: new Date()
+      });
+
       const authorizationId = v4();
 
       const values = {
@@ -186,9 +192,17 @@ export const authenticatePassword: GraphQLFieldConfig<
         }
       );
 
+      // Invoke the new authorization, since it will be used for the remainder
+      // of the request.
+      await authorization.invoke(tx, {
+        id: v4(),
+        format: "basic",
+        createdAt: new Date()
+      });
+
       await tx.query("COMMIT");
 
-      // use this authorization for the rest of the request
+      // Use this authorization for the remainder of the request.
       context.authorization = authorization;
 
       return authorization;

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -10,15 +10,15 @@
   "dependencies": {
     "@authx/authx": "^2.0.0",
     "@authx/strategy-password": "^1.0.0",
-    "@types/pg": "^7.14.0",
+    "@types/pg": "^7.14.1",
     "@types/uuid": "^3.4.6",
     "pg": "^7.17.0",
     "uuid": "^3.3.3"
   },
   "description": "",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.11.0",
-    "@typescript-eslint/parser": "^2.11.0",
+    "@typescript-eslint/eslint-plugin": "^2.15.0",
+    "@typescript-eslint/parser": "^2.15.0",
     "ava": "^2.4.0",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",

--- a/packages/tools/src/scripts/bootstrap.ts
+++ b/packages/tools/src/scripts/bootstrap.ts
@@ -15,6 +15,7 @@ export default async (): Promise<void> => {
 
   const user = new User({
     id: v4(),
+    recordId: v4(),
     enabled: true,
     type: "human",
     name: "AuthX Root User"
@@ -22,6 +23,7 @@ export default async (): Promise<void> => {
 
   const authority = new PasswordAuthority({
     id: v4(),
+    recordId: v4(),
     enabled: true,
     strategy: "password",
     name: "Password",
@@ -34,6 +36,7 @@ export default async (): Promise<void> => {
   const password = randomBytes(16).toString("hex");
   const credential = new PasswordCredential({
     id: v4(),
+    recordId: v4(),
     enabled: true,
     authorityId: authority.id,
     authorityUserId: user.id,
@@ -45,6 +48,7 @@ export default async (): Promise<void> => {
 
   const role = new Role({
     id: v4(),
+    recordId: v4(),
     enabled: true,
     name: "Super Administrator",
     description: "A super administrator has full access to all resources.",
@@ -54,6 +58,7 @@ export default async (): Promise<void> => {
 
   const authorization = new Authorization({
     id: v4(),
+    recordId: v4(),
     enabled: true,
     scopes: ["**:**:**"],
     userId: user.id,
@@ -70,7 +75,7 @@ export default async (): Promise<void> => {
       user: {
         data: user,
         metadata: {
-          recordId: v4(),
+          recordId: user.recordId,
           createdByAuthorizationId: authorization.id,
           createdAt: new Date()
         }
@@ -78,7 +83,7 @@ export default async (): Promise<void> => {
       authority: {
         data: authority,
         metadata: {
-          recordId: v4(),
+          recordId: authority.recordId,
           createdByAuthorizationId: authorization.id,
           createdAt: new Date()
         }
@@ -86,7 +91,7 @@ export default async (): Promise<void> => {
       credential: {
         data: credential,
         metadata: {
-          recordId: v4(),
+          recordId: credential.recordId,
           createdByAuthorizationId: authorization.id,
           createdAt: new Date()
         }
@@ -94,7 +99,7 @@ export default async (): Promise<void> => {
       role: {
         data: role,
         metadata: {
-          recordId: v4(),
+          recordId: role.recordId,
           createdByAuthorizationId: authorization.id,
           createdAt: new Date()
         }
@@ -102,7 +107,7 @@ export default async (): Promise<void> => {
       authorization: {
         data: authorization,
         metadata: {
-          recordId: v4(),
+          recordId: authorization.recordId,
           createdByAuthorizationId: authorization.id,
           createdAt: new Date(),
           createdByCredentialId: null

--- a/yarn.lock
+++ b/yarn.lock
@@ -585,10 +585,10 @@
   resolved "https://registry.yarnpkg.com/@types/pg-types/-/pg-types-1.11.5.tgz#1eebbe62b6772fcc75c18957a90f933d155e005b"
   integrity sha512-L8ogeT6vDzT1vxlW3KITTCt+BVXXVkLXfZ/XNm6UqbcJgxf+KPO7yjWx7dQQE8RW07KopL10x2gNMs41+IkMGQ==
 
-"@types/pg@^7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-7.14.0.tgz#aa67270638dbeb2e0ea532eed100819cd6ce4b85"
-  integrity sha512-BNR7pZubap5op5YjfWm5TWGciWbjmsbAq14fc8ydROej4DMK+u49YaVh9Cw9IE0MhnoQPcIAUSRdZDZPKlYV4A==
+"@types/pg@^7.14.1":
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-7.14.1.tgz#40358b57c34970f750f6a26e2a5463c9f4758136"
+  integrity sha512-gQgg4bLuykokypx4O1fwEzl5e6UjjyaBtN3znn5zhm0YB9BnKyHDw+e4cQY9rAPzpdM2qpJbn9TNzUazbmTsdw==
   dependencies:
     "@types/node" "*"
     "@types/pg-types" "*"
@@ -676,12 +676,23 @@
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
 
-"@typescript-eslint/eslint-plugin@^2.10.0", "@typescript-eslint/eslint-plugin@^2.11.0":
+"@typescript-eslint/eslint-plugin@^2.10.0":
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.14.0.tgz#c74447400537d4eb7aae1e31879ab43e6c662a8a"
   integrity sha512-sneOJ3Hu0m5whJiVIxGBZZZMxMJ7c0LhAJzeMJgHo+n5wFs+/6rSR/gl7crkdR2kNwfOOSdzdc0gMvatG4dX2Q==
   dependencies:
     "@typescript-eslint/experimental-utils" "2.14.0"
+    eslint-utils "^1.4.3"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/eslint-plugin@^2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.15.0.tgz#5442c30b687ffd576ff74cfea46a6d7bfb0ee893"
+  integrity sha512-XRJFznI5v4K1WvIrWmjFjBAdQWaUTz4xJEdqR7+wAFsv6Q9dP3mOlE6BMNT3pdlp9eF1+bC5m5LZTmLMqffCVw==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "2.15.0"
     eslint-utils "^1.4.3"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
@@ -696,7 +707,16 @@
     "@typescript-eslint/typescript-estree" "2.14.0"
     eslint-scope "^5.0.0"
 
-"@typescript-eslint/parser@^2.10.0", "@typescript-eslint/parser@^2.11.0":
+"@typescript-eslint/experimental-utils@2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.15.0.tgz#41e35313bfaef91650ddb5380846d1c78a780070"
+  integrity sha512-Qkxu5zndY5hqlcQkmA88gfLvqQulMpX/TN91XC7OuXsRf4XG5xLGie0sbpX97o/oeccjeZYRMipIsjKk/tjDHA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.15.0"
+    eslint-scope "^5.0.0"
+
+"@typescript-eslint/parser@^2.10.0":
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.14.0.tgz#30fa0523d86d74172a5e32274558404ba4262cd6"
   integrity sha512-haS+8D35fUydIs+zdSf4BxpOartb/DjrZ2IxQ5sR8zyGfd77uT9ZJZYF8+I0WPhzqHmfafUBx8MYpcp8pfaoSA==
@@ -706,10 +726,33 @@
     "@typescript-eslint/typescript-estree" "2.14.0"
     eslint-visitor-keys "^1.1.0"
 
+"@typescript-eslint/parser@^2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.15.0.tgz#379a71a51b0429bc3bc55c5f8aab831bf607e411"
+  integrity sha512-6iSgQsqAYTaHw59t0tdjzZJluRAjswdGltzKEdLtcJOxR2UVTPHYvZRqkAVGCkaMVb6Fpa60NnuozNCvsSpA9g==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "2.15.0"
+    "@typescript-eslint/typescript-estree" "2.15.0"
+    eslint-visitor-keys "^1.1.0"
+
 "@typescript-eslint/typescript-estree@2.14.0":
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.14.0.tgz#c67698acdc14547f095eeefe908958d93e1a648d"
   integrity sha512-pnLpUcMNG7GfFFfNQbEX6f1aPa5fMnH2G9By+A1yovYI4VIOK2DzkaRuUlIkbagpAcrxQHLqovI1YWqEcXyRnA==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash.unescape "4.0.1"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/typescript-estree@2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.15.0.tgz#79ae52eed8701b164d91e968a65d85a9105e76d3"
+  integrity sha512-L6Pog+w3VZzXkAdyqA0VlwybF8WcwZX+mufso86CMxSdWmcizJ38lgBdpqTbc9bo92iyi0rOvmATKiwl+amjxg==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -3306,12 +3349,12 @@ graphql-tools@^4.0.5:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-graphql@15.0.0-alpha.2, graphql@^14.5.3:
-  version "15.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.0.0-alpha.2.tgz#5c6277999702e7c649fbddb899e30039ff390436"
-  integrity sha512-OwI3D5b168+zbIb0NnjJyKbgonYW/QBACzVNZzdYSlGv5Jid1/UI5C1JEzIUAwWCoOKMuxMufaPmsDeu6vDGDg==
+graphql@15.0.0-rc.1, graphql@^14.5.3:
+  version "15.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.0.0-rc.1.tgz#246c5c02ee60d2fe2f670bf97847da9ad95e7e0c"
+  integrity sha512-yuuP9Pjtl6Pf2js/P9WKEcCBql3fTlYqBOX8EdW9Di/Y3VyK56tdK4KLULDsgIni5gcqv8GgtY5j/DMho+RXYw==
   dependencies:
-    iterall "^1.2.2"
+    iterall "^1.3.0"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -3985,10 +4028,15 @@ isobject@^4.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
 
-iterall@^1.1.3, iterall@^1.2.2:
+iterall@^1.1.3:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
   integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
+
+iterall@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
+  integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
 js-string-escape@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This fixes #72 by creating "invocations"  when a secret-containing entity is invoked. This PR does **not** address revealing this information via the GraphQL API, which can be addressed as a follow-up feature.

Because this requires a schema change (the addition of new tables) this is a breaking change.