### PR TITLE
Pin context of authorization.access to itself

### DIFF
--- a/packages/authx/src/graphql/mutation/createAuthorizations.ts
+++ b/packages/authx/src/graphql/mutation/createAuthorizations.ts
@@ -80,20 +80,12 @@ export const createAuthorizations: GraphQLFieldConfig<
 
       const tx = await pool.connect();
       try {
-        const values = {
-          currentAuthorizationId: a.id,
-          currentUserId: a.userId,
-          currentGrantId: a.grantId ?? null,
-          currentClientId: (await a.grant(tx))?.clientId ?? null
-        };
-
         const grant = input.grantId
           ? await Grant.read(tx, input.grantId)
           : null;
         if (
           !(await a.can(
             tx,
-            values,
             createV2AuthXScope(
               realm,
               {

--- a/packages/authx/src/graphql/mutation/createClients.ts
+++ b/packages/authx/src/graphql/mutation/createClients.ts
@@ -77,17 +77,9 @@ export const createClients: GraphQLFieldConfig<
 
       const tx = await pool.connect();
       try {
-        const values = {
-          currentAuthorizationId: a.id,
-          currentUserId: a.userId,
-          currentGrantId: a.grantId ?? null,
-          currentClientId: (await a.grant(tx))?.clientId ?? null
-        };
-
         if (
           !(await a.can(
             tx,
-            values,
             createV2AuthXScope(
               realm,
               {

--- a/packages/authx/src/graphql/mutation/createGrants.ts
+++ b/packages/authx/src/graphql/mutation/createGrants.ts
@@ -75,17 +75,9 @@ export const createGrants: GraphQLFieldConfig<
 
       const tx = await pool.connect();
       try {
-        const values = {
-          currentAuthorizationId: a.id,
-          currentUserId: a.userId,
-          currentGrantId: a.grantId ?? null,
-          currentClientId: (await a.grant(tx))?.clientId ?? null
-        };
-
         if (
           !(await a.can(
             tx,
-            values,
             createV2AuthXScope(
               realm,
               {

--- a/packages/authx/src/graphql/mutation/createRoles.ts
+++ b/packages/authx/src/graphql/mutation/createRoles.ts
@@ -74,17 +74,9 @@ export const createRoles: GraphQLFieldConfig<
 
       const tx = await pool.connect();
       try {
-        const values = {
-          currentAuthorizationId: a.id,
-          currentUserId: a.userId,
-          currentGrantId: a.grantId ?? null,
-          currentClientId: (await a.grant(tx))?.clientId ?? null
-        };
-
         if (
           !(await a.can(
             tx,
-            values,
             createV2AuthXScope(
               realm,
               {

--- a/packages/authx/src/graphql/mutation/createUsers.ts
+++ b/packages/authx/src/graphql/mutation/createUsers.ts
@@ -63,18 +63,10 @@ export const createUsers: GraphQLFieldConfig<
 
       const tx = await pool.connect();
       try {
-        const values = {
-          currentAuthorizationId: a.id,
-          currentUserId: a.userId,
-          currentGrantId: a.grantId ?? null,
-          currentClientId: (await a.grant(tx))?.clientId ?? null
-        };
-
         // can create a new user
         if (
           !(await a.can(
             tx,
-            values,
             createV2AuthXScope(
               realm,
               {

--- a/packages/authx/src/model/Authority.ts
+++ b/packages/authx/src/model/Authority.ts
@@ -65,17 +65,9 @@ export abstract class Authority<A> implements AuthorityData<A> {
       details: ""
     }
   ): Promise<boolean> {
-    const values = {
-      currentAuthorizationId: a.id,
-      currentUserId: a.userId,
-      currentGrantId: a.grantId ?? null,
-      currentClientId: (await a.grant(tx))?.clientId ?? null
-    };
-
     if (
       await a.can(
         tx,
-        values,
         createV2AuthXScope(
           realm,
           {

--- a/packages/authx/src/model/Client.ts
+++ b/packages/authx/src/model/Client.ts
@@ -88,17 +88,9 @@ export class Client implements ClientData {
       secrets: ""
     }
   ): Promise<boolean> {
-    const values = {
-      currentAuthorizationId: a.id,
-      currentUserId: a.userId,
-      currentGrantId: a.grantId ?? null,
-      currentClientId: (await a.grant(tx))?.clientId ?? null
-    };
-
     if (
       await a.can(
         tx,
-        values,
         createV2AuthXScope(
           realm,
           {

--- a/packages/authx/src/model/Credential.ts
+++ b/packages/authx/src/model/Credential.ts
@@ -89,17 +89,9 @@ export abstract class Credential<C> implements CredentialData<C> {
       details: ""
     }
   ): Promise<boolean> {
-    const values = {
-      currentAuthorizationId: a.id,
-      currentUserId: a.userId,
-      currentGrantId: a.grantId ?? null,
-      currentClientId: (await a.grant(tx))?.clientId ?? null
-    };
-
     if (
       await a.can(
         tx,
-        values,
         createV2AuthXScope(
           realm,
           {

--- a/packages/authx/src/model/Grant.ts
+++ b/packages/authx/src/model/Grant.ts
@@ -96,17 +96,9 @@ export class Grant implements GrantData {
       secrets: ""
     }
   ): Promise<boolean> {
-    const values = {
-      currentAuthorizationId: a.id,
-      currentUserId: a.userId,
-      currentGrantId: a.grantId ?? null,
-      currentClientId: (await a.grant(tx))?.clientId ?? null
-    };
-
     if (
       await a.can(
         tx,
-        values,
         createV2AuthXScope(
           realm,
           {

--- a/packages/authx/src/model/Role.ts
+++ b/packages/authx/src/model/Role.ts
@@ -69,17 +69,9 @@ export class Role implements RoleData {
       users: ""
     }
   ): Promise<boolean> {
-    const values = {
-      currentAuthorizationId: a.id,
-      currentUserId: a.userId,
-      currentGrantId: a.grantId ?? null,
-      currentClientId: (await a.grant(tx))?.clientId ?? null
-    };
-
     if (
       await a.can(
         tx,
-        values,
         createV2AuthXScope(
           realm,
           {

--- a/packages/authx/src/model/User.ts
+++ b/packages/authx/src/model/User.ts
@@ -68,17 +68,9 @@ export class User implements UserData {
       basic: "r"
     }
   ): Promise<boolean> {
-    const values = {
-      currentAuthorizationId: a.id,
-      currentUserId: a.userId,
-      currentGrantId: a.grantId ?? null,
-      currentClientId: (await a.grant(tx))?.clientId ?? null
-    };
-
     if (
       await a.can(
         tx,
-        values,
         createV2AuthXScope(
           realm,
           {

--- a/packages/authx/src/oauth2.ts
+++ b/packages/authx/src/oauth2.ts
@@ -561,11 +561,7 @@ async function oAuth2Middleware(
             }
           );
 
-          const scopes = await requestedAuthorization.access(tx, {
-            ...values,
-            currentAuthorizationId: requestedAuthorization.id
-          });
-
+          const scopes = await requestedAuthorization.access(tx);
           const tokenId = v4();
           await requestedAuthorization.invoke(tx, {
             id: tokenId,
@@ -863,12 +859,7 @@ async function oAuth2Middleware(
             );
           }
 
-          const scopes = await requestedAuthorization.access(tx, {
-            currentUserId: grant.userId,
-            currentGrantId: grant.id,
-            currentClientId: grant.clientId,
-            currentAuthorizationId: requestedAuthorization.id
-          });
+          const scopes = await requestedAuthorization.access(tx);
 
           const tokenId = v4();
           await requestedAuthorization.invoke(tx, {

--- a/packages/strategy-email/src/server/graphql/mutation/createEmailAuthorities.ts
+++ b/packages/strategy-email/src/server/graphql/mutation/createEmailAuthorities.ts
@@ -86,17 +86,9 @@ export const createEmailAuthorities: GraphQLFieldConfig<
 
       const tx = await pool.connect();
       try {
-        const values = {
-          currentAuthorizationId: a.id,
-          currentUserId: a.userId,
-          currentGrantId: a.grantId,
-          currentClientId: (await a.grant(tx))?.clientId ?? null
-        };
-
         if (
           !(await a.can(
             tx,
-            values,
             createV2AuthXScope(
               realm,
               {

--- a/packages/strategy-email/src/server/graphql/mutation/createEmailCredentials.ts
+++ b/packages/strategy-email/src/server/graphql/mutation/createEmailCredentials.ts
@@ -103,13 +103,6 @@ export const createEmailCredentials: GraphQLFieldConfig<
       try {
         await tx.query("BEGIN DEFERRABLE");
 
-        const values = {
-          currentAuthorizationId: a.id,
-          currentUserId: a.userId,
-          currentGrantId: a.grantId,
-          currentClientId: (await a.grant(tx))?.clientId ?? null
-        };
-
         // Make sure the ID isn't already in use.
         if (input.id) {
           try {
@@ -163,7 +156,6 @@ export const createEmailCredentials: GraphQLFieldConfig<
         if (
           !(await a.can(
             tx,
-            values,
             createV2AuthXScope(
               realm,
               {
@@ -188,7 +180,6 @@ export const createEmailCredentials: GraphQLFieldConfig<
         if (
           !(await a.can(
             tx,
-            values,
             createV2AuthXScope(
               realm,
               {

--- a/packages/strategy-openid/src/server/graphql/mutation/createOpenIdAuthorities.ts
+++ b/packages/strategy-openid/src/server/graphql/mutation/createOpenIdAuthorities.ts
@@ -86,17 +86,9 @@ export const createOpenIdAuthorities: GraphQLFieldConfig<
 
       const tx = await pool.connect();
       try {
-        const values = {
-          currentAuthorizationId: a.id,
-          currentUserId: a.userId,
-          currentGrantId: a.grantId,
-          currentClientId: (await a.grant(tx))?.clientId ?? null
-        };
-
         if (
           !(await a.can(
             tx,
-            values,
             createV2AuthXScope(
               realm,
               {

--- a/packages/strategy-openid/src/server/graphql/mutation/createOpenIdCredentials.ts
+++ b/packages/strategy-openid/src/server/graphql/mutation/createOpenIdCredentials.ts
@@ -104,13 +104,6 @@ export const createOpenIdCredentials: GraphQLFieldConfig<
       try {
         await tx.query("BEGIN DEFERRABLE");
 
-        const values = {
-          currentAuthorizationId: a.id,
-          currentUserId: a.userId,
-          currentGrantId: a.grantId,
-          currentClientId: (await a.grant(tx))?.clientId ?? null
-        };
-
         // Make sure the ID isn't already in use.
         if (input.id) {
           try {
@@ -280,7 +273,6 @@ export const createOpenIdCredentials: GraphQLFieldConfig<
         if (
           !(await a.can(
             tx,
-            values,
             createV2AuthXScope(
               realm,
               {
@@ -307,7 +299,6 @@ export const createOpenIdCredentials: GraphQLFieldConfig<
         if (
           !(await a.can(
             tx,
-            values,
             createV2AuthXScope(
               realm,
               {

--- a/packages/strategy-password/src/server/graphql/mutation/createPasswordAuthorities.ts
+++ b/packages/strategy-password/src/server/graphql/mutation/createPasswordAuthorities.ts
@@ -78,17 +78,9 @@ export const createPasswordAuthorities: GraphQLFieldConfig<
 
       const tx = await pool.connect();
       try {
-        const values = {
-          currentAuthorizationId: a.id,
-          currentUserId: a.userId,
-          currentGrantId: a.grantId,
-          currentClientId: (await a.grant(tx))?.clientId ?? null
-        };
-
         if (
           !(await a.can(
             tx,
-            values,
             createV2AuthXScope(
               realm,
               {

--- a/packages/strategy-password/src/server/graphql/mutation/createPasswordCredentials.ts
+++ b/packages/strategy-password/src/server/graphql/mutation/createPasswordCredentials.ts
@@ -99,18 +99,10 @@ export const createPasswordCredentials: GraphQLFieldConfig<
 
       const tx = await pool.connect();
       try {
-        const values = {
-          currentAuthorizationId: a.id,
-          currentUserId: a.userId,
-          currentGrantId: a.grantId,
-          currentClientId: (await a.grant(tx))?.clientId ?? null
-        };
-
         // The user cannot create a credential for this user and authority.
         if (
           !(await a.can(
             tx,
-            values,
             createV2AuthXScope(
               realm,
               {


### PR DESCRIPTION
There is no use case for evaluating an authorization's access in
the context of a different authorization, which can only lead to
mistakes.