### PR TITLE
Web proxy basic token

### DIFF
--- a/packages/authx/src/model/rules/CursorRule.ts
+++ b/packages/authx/src/model/rules/CursorRule.ts
@@ -5,10 +5,10 @@ import { ReverseCursorRule } from "./ReverseCursorRule";
 
 export class CursorRule {
   static create(args: ConnectionArguments): Rule | null {
-    if (typeof args.after == "string" || typeof args.first == "number") {
+    if (typeof args.after === "string" || typeof args.first === "number") {
       return new ForwardCursorRule(args);
     }
-    if (typeof args.before == "string" || typeof args.last == "number") {
+    if (typeof args.before === "string" || typeof args.last === "number") {
       return new ReverseCursorRule(args);
     }
 

--- a/packages/authx/src/model/rules/IsAccessibleByRule.ts
+++ b/packages/authx/src/model/rules/IsAccessibleByRule.ts
@@ -88,7 +88,7 @@ export class IsAccessibleByRule extends Rule {
               ] !== "undefined"
             ) {
               const value = extracted.parameters[key];
-              if (value == "*") {
+              if (value === "*") {
                 hasAtLeastOneStar = true;
               } else if (value) {
                 fixedId[key] = value;
@@ -100,7 +100,7 @@ export class IsAccessibleByRule extends Rule {
 
           if (scopeCorrupted) continue;
 
-          if (hasAtLeastOneStar && Object.keys(fixedId).length == 0) {
+          if (hasAtLeastOneStar && Object.keys(fixedId).length === 0) {
             allAccess = true;
             break;
           } else if (Object.keys(fixedId).length > 0) {
@@ -109,7 +109,7 @@ export class IsAccessibleByRule extends Rule {
         }
       }
 
-      if (!allAccess && fixedIds.length == 0) {
+      if (!allAccess && fixedIds.length === 0) {
         // this authorization can't access this entity at all
         this.where = "FALSE";
       } else if (!allAccess) {

--- a/packages/authx/src/model/rules/Rule.ts
+++ b/packages/authx/src/model/rules/Rule.ts
@@ -46,7 +46,7 @@ export class Rule {
       .map(it => it.toSQLOrder())
       .filter(it => it);
 
-    if (orderByClauseElements.length == 1) {
+    if (orderByClauseElements.length === 1) {
       ret += ` ${orderByClauseElements[0]}`;
     } else if (orderByClauseElements.length > 1) {
       throw "Only one ORDER BY element is allowed in rules";
@@ -56,7 +56,7 @@ export class Rule {
       .map(it => it.toSQLLimit())
       .filter(it => it);
 
-    if (limitClauseElements.length == 1) {
+    if (limitClauseElements.length === 1) {
       ret += ` LIMIT ${limitClauseElements[0]}`;
     } else if (limitClauseElements.length > 1) {
       throw "Only one LIMIT element is allowed in rules";

--- a/packages/authx/src/oauth2.ts
+++ b/packages/authx/src/oauth2.ts
@@ -925,7 +925,7 @@ async function prepareOAuthResponse(
   jwtValidityDuration: number,
   realm: string
 ): Promise<any> {
-  if (typeof tokenFormat == "undefined") tokenFormat = "BEARER";
+  if (typeof tokenFormat === "undefined") tokenFormat = "BEARER";
 
   const scopes = await requestedAuthorization.access(executor);
   const tokenId = v4();
@@ -935,7 +935,7 @@ async function prepareOAuthResponse(
     createdAt: new Date()
   });
 
-  if (tokenFormat == "BEARER") {
+  if (tokenFormat === "BEARER") {
     return {
       /* eslint-disable camelcase */
       token_type: "bearer",
@@ -960,7 +960,7 @@ async function prepareOAuthResponse(
       scope: scopes.join(" ")
       /* eslint-enable camelcase */
     };
-  } else if (tokenFormat == "BASIC") {
+  } else if (tokenFormat === "BASIC") {
     const tokenRaw = `${requestedAuthorization.id}:${requestedAuthorization.secret}`;
 
     return {

--- a/packages/http-proxy-client/src/index.ts
+++ b/packages/http-proxy-client/src/index.ts
@@ -6,7 +6,7 @@ import { createServer, Server, IncomingMessage, ServerResponse } from "http";
 import { createProxyServer, ServerOptions } from "http-proxy";
 import { decode } from "jsonwebtoken";
 
-interface Behavior {
+export interface Behavior {
   /**
    * The options to pass to node-proxy.
    *
@@ -51,7 +51,7 @@ interface Behavior {
   readonly sendTokenToTargetWithScopes?: string[];
 }
 
-interface Rule {
+export interface Rule {
   /**
    * Each rule is tested in order, with the first to return `true` used to
    * handle the request. This function MUST NOT manipulate the `request` object.
@@ -78,7 +78,7 @@ interface Rule {
       ) => Behavior | undefined);
 }
 
-interface Config {
+export interface Config {
   /**
    * The root URL to AuthX server.
    */

--- a/packages/http-proxy-resource/src/index.ts
+++ b/packages/http-proxy-resource/src/index.ts
@@ -13,7 +13,7 @@ export {
   NotAuthorizedError
 } from "./validateAuthorizationHeader";
 
-interface Behavior {
+export interface Behavior {
   /**
    * The options to pass to node-proxy.
    *
@@ -55,7 +55,7 @@ interface Behavior {
   readonly requireScopes?: string[];
 }
 
-interface Rule {
+export interface Rule {
   /**
    * Each rule is tested in order, with the first to return `true` used to
    * handle the request. This function MUST NOT manipulate the `request` object.
@@ -82,7 +82,7 @@ interface Rule {
       ) => Behavior | undefined);
 }
 
-interface Config {
+export interface Config {
   /**
    * The root URL to AuthX server.
    */


### PR DESCRIPTION
I went to change the configs for one of the dashboards and realized the proxy makes assumptions about the format of the token. This also adds tests and swaps out "coercing equals (`==`)" for "strict equals (`===`)" in places, just to match the rest of the codebase style.