### PR TITLE
Fix #284 - allow authorization introspection

### DIFF
--- a/packages/authx/src/graphql/GraphQLAuthorization.ts
+++ b/packages/authx/src/graphql/GraphQLAuthorization.ts
@@ -128,7 +128,7 @@ export const GraphQLAuthorization: GraphQLObjectType<
           scopes: "r",
           secrets: "",
         }))
-          ? authorization.access(executor)
+          ? authorization.access(executor, realm)
           : null;
       },
     },
@@ -185,7 +185,7 @@ export const GraphQLAuthorization: GraphQLObjectType<
           return `Bearer ${jwt.sign(
             {
               aid: authorization.id,
-              scopes: await authorization.access(executor),
+              scopes: await authorization.access(executor, realm),
             },
             privateKey,
             {

--- a/packages/authx/src/graphql/mutation/createAuthorizations.ts
+++ b/packages/authx/src/graphql/mutation/createAuthorizations.ts
@@ -109,6 +109,7 @@ export const createAuthorizations: GraphQLFieldConfig<
         if (
           !(await a.can(
             executor,
+            realm,
             createV2AuthXScope(
               realm,
               {

--- a/packages/authx/src/graphql/mutation/createClients.ts
+++ b/packages/authx/src/graphql/mutation/createClients.ts
@@ -96,6 +96,7 @@ export const createClients: GraphQLFieldConfig<
         if (
           !(await a.can(
             executor,
+            realm,
             createV2AuthXScope(
               realm,
               {

--- a/packages/authx/src/graphql/mutation/createGrants.ts
+++ b/packages/authx/src/graphql/mutation/createGrants.ts
@@ -94,6 +94,7 @@ export const createGrants: GraphQLFieldConfig<
         if (
           !(await a.can(
             executor,
+            realm,
             createV2AuthXScope(
               realm,
               {

--- a/packages/authx/src/graphql/mutation/createRoles.ts
+++ b/packages/authx/src/graphql/mutation/createRoles.ts
@@ -93,6 +93,7 @@ export const createRoles: GraphQLFieldConfig<
         if (
           !(await a.can(
             executor,
+            realm,
             createV2AuthXScope(
               realm,
               {

--- a/packages/authx/src/graphql/mutation/createUsers.ts
+++ b/packages/authx/src/graphql/mutation/createUsers.ts
@@ -83,6 +83,7 @@ export const createUsers: GraphQLFieldConfig<
         if (
           !(await a.can(
             executor,
+            realm,
             createV2AuthXScope(
               realm,
               {

--- a/packages/authx/src/graphql/query/authorizations.ts
+++ b/packages/authx/src/graphql/query/authorizations.ts
@@ -36,7 +36,11 @@ export const authorizations: GraphQLFieldConfig<
     const rules = CursorRule.addToRuleListIfNeeded(
       [
         new NoReplacementRecord(),
-        new IsAccessibleByRule(realm, a, "authorization"),
+        new IsAccessibleByRule(
+          realm,
+          await a.access(executor, realm),
+          "authorization"
+        ),
       ],
       args
     );

--- a/packages/authx/src/graphql/query/clients.ts
+++ b/packages/authx/src/graphql/query/clients.ts
@@ -34,7 +34,14 @@ export const clients: GraphQLFieldConfig<
     if (!a) return [];
 
     const rules = CursorRule.addToRuleListIfNeeded(
-      [new NoReplacementRecord(), new IsAccessibleByRule(realm, a, "client")],
+      [
+        new NoReplacementRecord(),
+        new IsAccessibleByRule(
+          realm,
+          await a.access(executor, realm),
+          "client"
+        ),
+      ],
       args
     );
 

--- a/packages/authx/src/graphql/query/credentials.ts
+++ b/packages/authx/src/graphql/query/credentials.ts
@@ -36,7 +36,11 @@ export const credentials: GraphQLFieldConfig<
     const rules = CursorRule.addToRuleListIfNeeded(
       [
         new NoReplacementRecord(),
-        new IsAccessibleByRule(realm, a, "credential"),
+        new IsAccessibleByRule(
+          realm,
+          await a.access(executor, realm),
+          "credential"
+        ),
       ],
       args
     );

--- a/packages/authx/src/graphql/query/grants.ts
+++ b/packages/authx/src/graphql/query/grants.ts
@@ -34,7 +34,10 @@ export const grants: GraphQLFieldConfig<
     if (!a) return [];
 
     const rules = CursorRule.addToRuleListIfNeeded(
-      [new NoReplacementRecord(), new IsAccessibleByRule(realm, a, "grant")],
+      [
+        new NoReplacementRecord(),
+        new IsAccessibleByRule(realm, await a.access(executor, realm), "grant"),
+      ],
       args
     );
 

--- a/packages/authx/src/graphql/query/roles.ts
+++ b/packages/authx/src/graphql/query/roles.ts
@@ -34,7 +34,10 @@ export const roles: GraphQLFieldConfig<
     if (!a) return [];
 
     const rules = CursorRule.addToRuleListIfNeeded(
-      [new NoReplacementRecord(), new IsAccessibleByRule(realm, a, "role")],
+      [
+        new NoReplacementRecord(),
+        new IsAccessibleByRule(realm, await a.access(executor, realm), "role"),
+      ],
       args
     );
 

--- a/packages/authx/src/graphql/query/users.ts
+++ b/packages/authx/src/graphql/query/users.ts
@@ -34,7 +34,10 @@ export const users: GraphQLFieldConfig<
     if (!a) return [];
 
     const rules = CursorRule.addToRuleListIfNeeded(
-      [new NoReplacementRecord(), new IsAccessibleByRule(realm, a, "user")],
+      [
+        new NoReplacementRecord(),
+        new IsAccessibleByRule(realm, await a.access(executor, realm), "user"),
+      ],
       args
     );
 

--- a/packages/authx/src/model/Authority.ts
+++ b/packages/authx/src/model/Authority.ts
@@ -77,6 +77,7 @@ export abstract class Authority<A> implements AuthorityData<A> {
     if (
       await a.can(
         tx,
+        realm,
         createV2AuthXScope(
           realm,
           {

--- a/packages/authx/src/model/Client.ts
+++ b/packages/authx/src/model/Client.ts
@@ -90,6 +90,7 @@ export class Client implements ClientData {
     if (
       await a.can(
         tx,
+        realm,
         createV2AuthXScope(
           realm,
           {

--- a/packages/authx/src/model/Credential.ts
+++ b/packages/authx/src/model/Credential.ts
@@ -99,6 +99,7 @@ export abstract class Credential<C> implements CredentialData<C> {
     if (
       await a.can(
         tx,
+        realm,
         createV2AuthXScope(
           realm,
           {

--- a/packages/authx/src/model/Grant.ts
+++ b/packages/authx/src/model/Grant.ts
@@ -96,6 +96,7 @@ export class Grant implements GrantData {
     if (
       await a.can(
         tx,
+        realm,
         createV2AuthXScope(
           realm,
           {

--- a/packages/authx/src/model/Role.ts
+++ b/packages/authx/src/model/Role.ts
@@ -71,6 +71,7 @@ export class Role implements RoleData {
     if (
       await a.can(
         tx,
+        realm,
         createV2AuthXScope(
           realm,
           {

--- a/packages/authx/src/model/User.ts
+++ b/packages/authx/src/model/User.ts
@@ -67,6 +67,7 @@ export class User implements UserData {
     if (
       await a.can(
         tx,
+        realm,
         createV2AuthXScope(
           realm,
           {

--- a/packages/authx/src/model/rules/IsAccessibleByRule.ts
+++ b/packages/authx/src/model/rules/IsAccessibleByRule.ts
@@ -1,6 +1,17 @@
 import { Rule } from "./Rule";
-import { Authorization } from "../Authorization";
 import { extract } from "@authx/scopes";
+
+/**
+ * Note that the entity type "authority" is intentionally omitted, because it is
+ * always accessible.
+ */
+type AccessibleEntityType =
+  | "authorization"
+  | "client"
+  | "credential"
+  | "grant"
+  | "role"
+  | "user";
 
 /**
  * Rule that handles pagination if the user is paging backwards through the data
@@ -14,8 +25,8 @@ import { extract } from "@authx/scopes";
 export class IsAccessibleByRule extends Rule {
   constructor(
     private readonly realm: string,
-    private readonly authorization: Authorization,
-    private readonly entityType: string
+    private readonly access: string[],
+    private readonly entityType: AccessibleEntityType
   ) {
     super();
   }
@@ -73,7 +84,7 @@ export class IsAccessibleByRule extends Rule {
       const fixedIds: { [key: string]: string }[] = [];
       let allAccess = false;
 
-      for (const scope of this.authorization.scopes) {
+      for (const scope of this.access) {
         const extractedScopes = extract(template, [scope]);
 
         for (const extracted of extractedScopes) {

--- a/packages/authx/src/oauth2.ts
+++ b/packages/authx/src/oauth2.ts
@@ -927,7 +927,7 @@ async function prepareOAuthResponse(
 ): Promise<any> {
   if (typeof tokenFormat === "undefined") tokenFormat = "BEARER";
 
-  const scopes = await requestedAuthorization.access(executor);
+  const scopes = await requestedAuthorization.access(executor, realm);
   const tokenId = v4();
   await requestedAuthorization.invoke(executor, {
     id: tokenId,

--- a/packages/strategy-email/src/server/graphql/mutation/createEmailAuthorities.ts
+++ b/packages/strategy-email/src/server/graphql/mutation/createEmailAuthorities.ts
@@ -101,6 +101,7 @@ export const createEmailAuthorities: GraphQLFieldConfig<
         if (
           !(await a.can(
             executor,
+            realm,
             createV2AuthXScope(
               realm,
               {

--- a/packages/strategy-email/src/server/graphql/mutation/createEmailCredentials.ts
+++ b/packages/strategy-email/src/server/graphql/mutation/createEmailCredentials.ts
@@ -164,6 +164,7 @@ export const createEmailCredentials: GraphQLFieldConfig<
         if (
           !(await a.can(
             executor,
+            realm,
             createV2AuthXScope(
               realm,
               {
@@ -188,6 +189,7 @@ export const createEmailCredentials: GraphQLFieldConfig<
         if (
           !(await a.can(
             executor,
+            realm,
             createV2AuthXScope(
               realm,
               {

--- a/packages/strategy-openid/src/server/graphql/mutation/createOpenIdAuthorities.ts
+++ b/packages/strategy-openid/src/server/graphql/mutation/createOpenIdAuthorities.ts
@@ -101,6 +101,7 @@ export const createOpenIdAuthorities: GraphQLFieldConfig<
         if (
           !(await a.can(
             executor,
+            realm,
             createV2AuthXScope(
               realm,
               {

--- a/packages/strategy-openid/src/server/graphql/mutation/createOpenIdCredentials.ts
+++ b/packages/strategy-openid/src/server/graphql/mutation/createOpenIdCredentials.ts
@@ -282,6 +282,7 @@ export const createOpenIdCredentials: GraphQLFieldConfig<
         if (
           !(await a.can(
             executor,
+            realm,
             createV2AuthXScope(
               realm,
               {
@@ -308,6 +309,7 @@ export const createOpenIdCredentials: GraphQLFieldConfig<
         if (
           !(await a.can(
             executor,
+            realm,
             createV2AuthXScope(
               realm,
               {

--- a/packages/strategy-password/src/server/graphql/mutation/createPasswordAuthorities.ts
+++ b/packages/strategy-password/src/server/graphql/mutation/createPasswordAuthorities.ts
@@ -93,6 +93,7 @@ export const createPasswordAuthorities: GraphQLFieldConfig<
         if (
           !(await a.can(
             executor,
+            realm,
             createV2AuthXScope(
               realm,
               {

--- a/packages/strategy-password/src/server/graphql/mutation/createPasswordCredentials.ts
+++ b/packages/strategy-password/src/server/graphql/mutation/createPasswordCredentials.ts
@@ -111,6 +111,7 @@ export const createPasswordCredentials: GraphQLFieldConfig<
         if (
           !(await a.can(
             executor,
+            realm,
             createV2AuthXScope(
               realm,
               {


### PR DESCRIPTION
This implements the feature described in #284 by injecting the scope:
```
authx:v2.authorization..*.{current_client_id}..{current_grant_id}..{current_user_id}:r..*..
```
into the result or an active authorization's `.access` method, and ensuring that this method is used elsewhere.