### PR TITLE
Use narrow scopes in OAuth2 auth code flow

### DIFF
--- a/packages/authx/src/index.ts
+++ b/packages/authx/src/index.ts
@@ -3,7 +3,7 @@ import { v4 } from "uuid";
 import createPlaygroundMiddleware from "graphql-playground-middleware-koa";
 import Router, { IRouterOptions } from "koa-router";
 import { errorHandler, execute } from "graphql-api-koa";
-import { Context as KoaContext, Next as KoaNext } from "koa";
+import { Context as KoaContext, Next as KoaNext, Middleware } from "koa";
 import { parse } from "auth-header";
 import { Pool } from "pg";
 
@@ -29,10 +29,7 @@ export * from "./Config";
 export * from "./Context";
 export * from "./util/validateIdFormat";
 
-// FIXME: The newest types from @types/koa fail to match perfectly valid
-// overloads for chained middleware. I haven't had a chance to really dive into
-// what's going on, so for now we are going to cast through any.
-type AuthXMiddleware = any; // Middleware<any, KoaContext & { [x]: Context }>
+type AuthXMiddleware = Middleware<any, KoaContext & { [x]: Context }>;
 
 export class AuthX extends Router<any, { [x]: Context }> {
   public readonly pool: Pool;

--- a/packages/http-proxy-web/src/index.ts
+++ b/packages/http-proxy-web/src/index.ts
@@ -384,7 +384,7 @@ export default class AuthXWebProxy extends EventEmitter {
             client_secret: this._config.clientSecret,
             code: code,
             token_format: this._config.tokenFormat,
-            scope: "**:**:**",
+            scope: this._config.requestGrantedScopes.join(" "),
             /* eslint-enable camelcase */
           }),
         });
@@ -404,14 +404,6 @@ export default class AuthXWebProxy extends EventEmitter {
         // Update the refresh token.
         if (tokenResponseBody.refresh_token) {
           cookies.set("authx.r", tokenResponseBody.refresh_token);
-        }
-
-        // Use the new access token.
-        if (tokenResponseBody.access_token) {
-          cookies.set(
-            `authx.t.${hashScopes(["**:**:**"])}`,
-            tokenResponseBody.access_token
-          );
         }
 
         response.setHeader("Location", cookies.get("authx.d") || "/");

--- a/packages/tools/src/lib/fixture/client.ts
+++ b/packages/tools/src/lib/fixture/client.ts
@@ -62,6 +62,7 @@ export const client = [
           urls: [
             "https://www.dundermifflin.com",
             "https://admin.dundermifflin.com",
+            "http://localhost",
           ],
         },
         {

--- a/src/superadmin.test.ts
+++ b/src/superadmin.test.ts
@@ -237,6 +237,7 @@ test("Root query fields.", async (t) => {
               urls: [
                 "https://www.dundermifflin.com",
                 "https://admin.dundermifflin.com",
+                "http://localhost",
               ],
             },
             secrets: [


### PR DESCRIPTION
This modifies the authorization code flow to return an access token with scopes limited by those provided in the request.

Fixes #296