### PR TITLE
persist url for SAML redirection

### DIFF
--- a/main.sublime-project
+++ b/main.sublime-project
@@ -38,6 +38,10 @@
       "folder_exclude_patterns": ["**/node_modules", "**/dist"]
     },
     {
+      "path": "packages/strategy-saml",
+      "folder_exclude_patterns": ["**/node_modules", "**/dist"]
+    },
+    {
       "path": "packages/tools",
       "folder_exclude_patterns": ["**/node_modules", "**/dist"]
     },

--- a/packages/strategy-saml/src/interface/SamlAuthority.tsx
+++ b/packages/strategy-saml/src/interface/SamlAuthority.tsx
@@ -43,7 +43,7 @@ export function SamlAuthority({
       ) {
         setAuthorization({
           id: cookieMap.samlFinishedAuthorizationId,
-          secret: cookieMap.samlFinishedAuthorizationSecret,
+          secret: cookieMap["strategy.saml.authorization_secret"],
         });
         window.document.cookie = "strategy.saml.authorization_id=";
         window.document.cookie = "strategy.saml.authorization_secret=";

--- a/packages/strategy-saml/src/interface/SamlAuthority.tsx
+++ b/packages/strategy-saml/src/interface/SamlAuthority.tsx
@@ -45,8 +45,9 @@ export function SamlAuthority({
           id: cookieMap.samlFinishedAuthorizationId,
           secret: cookieMap.samlFinishedAuthorizationSecret,
         });
-        window.document.cookie = "samlFinishedAuthorizationId=";
-        window.document.cookie = "samlFinishedAuthorizationSecret=";
+        window.document.cookie = "strategy.saml.authorization_id=";
+        window.document.cookie = "strategy.saml.authorization_secret=";
+        window.document.cookie = "strategy.saml.destination=";
       }
 
       const params = new URLSearchParams(window.location.search);
@@ -62,6 +63,12 @@ export function SamlAuthority({
   const [errors, setErrors] = useState<string[]>([]);
   async function onSubmit(e: FormEvent): Promise<void> {
     e.preventDefault();
+
+    // Save the current URL for internal redirection.
+    window.document.cookie = `strategy.saml.destination=${encodeURIComponent(
+      window.location.href
+    )}`;
+
     window.location.href = authority.authUrlWithParams;
   }
 

--- a/packages/strategy-saml/src/interface/SamlAuthority.tsx
+++ b/packages/strategy-saml/src/interface/SamlAuthority.tsx
@@ -38,8 +38,8 @@ export function SamlAuthority({
       }
 
       if (
-        cookieMap.samlFinishedAuthorizationId &&
-        cookieMap.samlFinishedAuthorizationSecret
+        cookieMap["strategy.saml.authorization_id"] &&
+        cookieMap["strategy.saml.authorization_secret"]
       ) {
         setAuthorization({
           id: cookieMap["strategy.saml.authorization_id"],

--- a/packages/strategy-saml/src/interface/SamlAuthority.tsx
+++ b/packages/strategy-saml/src/interface/SamlAuthority.tsx
@@ -42,7 +42,7 @@ export function SamlAuthority({
         cookieMap.samlFinishedAuthorizationSecret
       ) {
         setAuthorization({
-          id: cookieMap.samlFinishedAuthorizationId,
+          id: cookieMap["strategy.saml.authorization_id"],
           secret: cookieMap["strategy.saml.authorization_secret"],
         });
         window.document.cookie = "strategy.saml.authorization_id=";

--- a/packages/strategy-saml/src/server/samlRouter.ts
+++ b/packages/strategy-saml/src/server/samlRouter.ts
@@ -46,19 +46,22 @@ export function samlRouterFactory(): Router<any, { [x]: Context }> {
             .join("&")}&authorityId=${encodeURIComponent(authorityId)}`
         );
       } else {
-        console.log(data);
-
         ctx.cookies.set(
-          "samlFinishedAuthorizationId",
+          "strategy.saml.authorization_id",
           data.data.authenticateSaml.id,
           { httpOnly: false }
         );
         ctx.cookies.set(
-          "samlFinishedAuthorizationSecret",
+          "strategy.saml.authorization_secret",
           data.data.authenticateSaml.secret,
           { httpOnly: false }
         );
-        ctx.redirect(`${base}?authorityId=${encodeURIComponent(authorityId)}`);
+
+        const destination =
+          ctx.cookies.get("window.document.cookie") ||
+          `${base}?authorityId=${encodeURIComponent(authorityId)}`;
+
+        ctx.redirect(destination);
       }
     }
   );

--- a/packages/strategy-saml/src/server/samlRouter.ts
+++ b/packages/strategy-saml/src/server/samlRouter.ts
@@ -57,11 +57,16 @@ export function samlRouterFactory(): Router<any, { [x]: Context }> {
           { httpOnly: false }
         );
 
-        const destination =
-          ctx.cookies.get("window.document.cookie") ||
-          `${base}?authorityId=${encodeURIComponent(authorityId)}`;
+        const destination = decodeURIComponent(
+          ctx.cookies.get("strategy.saml.destination", {
+            signed: false,
+          }) ?? ""
+        );
 
-        ctx.redirect(destination);
+        ctx.redirect(
+          destination ||
+            `${base}?authorityId=${encodeURIComponent(authorityId)}`
+        );
       }
     }
   );


### PR DESCRIPTION
Currently, logging in with SAML loses parameters stored in the the URL, including those necessary for OAuth from a client. This persists the current URL in a cookie before performing the redirect to the IDP.

Additionally, this changes the cookie names such that they are namespaced by the strategy identifier. This should help avoid conflicts and provide more predictable naming for cookies across strategies/plugins.