### PR TITLE
Fix method to only query enabled grants

### DIFF
--- a/packages/authx/src/model/User.ts
+++ b/packages/authx/src/model/User.ts
@@ -192,6 +192,7 @@ export class User implements UserData {
         user_id = $1
         AND client_id = $2
         AND replacement_record_id IS NULL
+        AND enabled = TRUE
       ORDER BY id ASC
       `,
       [this.id, clientId]


### PR DESCRIPTION
This method is intended to find the active grant between a user and client. However, it incorrectly did not enforce `enabled = TRUE` in its query.