### PR TITLE
Fix #253 - Denormalize replacement_record_id onto role_record_user

### DIFF
--- a/packages/authx/schema.sql
+++ b/packages/authx/schema.sql
@@ -136,14 +136,18 @@ CREATE TABLE authx.role_record (
 
 CREATE UNIQUE INDEX ON authx.role_record USING BTREE (entity_id) WHERE replacement_record_id IS NULL;
 CREATE UNIQUE INDEX ON authx.role_record USING BTREE (entity_id, record_id);
+CREATE UNIQUE INDEX ON authx.role_record USING BTREE (record_id, replacement_record_id);
 
 CREATE TABLE authx.role_record_user (
-  role_record_id UUID NOT NULL REFERENCES authx.role_record,
-  user_id UUID REFERENCES authx.user,
-  PRIMARY KEY(role_record_id, user_id)
+  role_record_id UUID NOT NULL,
+  role_replacement_record_id UUID DEFAULT NULL,
+  user_id UUID NOT NULL REFERENCES authx.user,
+  PRIMARY KEY (role_record_id, user_id),
+  FOREIGN KEY (role_record_id, role_replacement_record_id) REFERENCES authx.role_record (record_id, replacement_record_id) DEFERRABLE INITIALLY DEFERRED
 );
 
 CREATE INDEX ON authx.role_record_user USING BTREE (user_id, role_record_id);
+CREATE INDEX ON authx.role_record_user USING BTREE (role_record_id, role_replacement_record_id);
 
 
 

--- a/packages/authx/src/model/User.ts
+++ b/packages/authx/src/model/User.ts
@@ -220,17 +220,34 @@ export class User implements UserData {
       const ids = (
         await queryCache.query(
           tx,
-          `
-        SELECT entity_id AS id
-        FROM authx.role_record
-        JOIN authx.role_record_user
-          ON authx.role_record_user.role_record_id = authx.role_record.record_id
-        WHERE
-          authx.role_record_user.user_id = $1
-          AND authx.role_record.enabled = TRUE
-          AND authx.role_record.replacement_record_id IS NULL
-        ORDER BY id ASC
-        `,
+          // This provides a mechanism for denormalizing the role replacement
+          // record ID into the relation table while minimizing production
+          // impact. By upgrading the application but keeping this environment
+          // varuable set to "true", read operations will continue to work as
+          // the schema is migrated.
+          process.env.AUTHX_ROLE_SCHEMA_MIGRATION === "true"
+            ? `
+              SELECT entity_id AS id
+              FROM authx.role_record
+              JOIN authx.role_record_user
+                ON authx.role_record_user.role_record_id = authx.role_record.record_id
+              WHERE
+                authx.role_record_user.user_id = $1
+                AND authx.role_record.enabled = TRUE
+                AND authx.role_record.replacement_record_id IS NULL
+              ORDER BY id ASC
+              `
+            : `
+              SELECT entity_id AS id
+              FROM authx.role_record
+              JOIN authx.role_record_user
+                ON authx.role_record_user.role_record_id = authx.role_record.record_id
+              WHERE
+                authx.role_record_user.user_id = $1
+                AND authx.role_record_user.role_replacement_record_id IS NULL
+                AND authx.role_record.enabled = TRUE
+              ORDER BY id ASC
+              `,
           [this.id]
         )
       ).rows.map(({ id }) => id);


### PR DESCRIPTION
This fixes #253 by denormalizing replacement_record_id onto role_record_user.

It also adds a _temporary_ flag: when the `AUTHX_ROLE_SCHEMA_MIGRATION` environment variable is set to `true` read queries will use the _old_ queries which to not make use of the new columns. This should allow normal functioning while the schema is being migrated.

The expected migration path is as follows:

1. Deploy the new version with `AUTHX_ROLE_SCHEMA_MIGRATION=true`
2. Add the `role_replacement_record_id` column to `role_record_user`
3. Add indices to `role_record` and `role_record_user`
4. Backfill `role_record_user.role_replacement_record_id` from `role.replacement_record_id`
5. Replace foreign key constraint on `role_record_user`
6. Remove the `AUTHX_ROLE_SCHEMA_MIGRATION` flag
