### PR TITLE
Mutation tweaks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,10 @@ By default, running `up` does _not_ create the database schema or fill it with f
 
 ```bash
 # Create the authx database schema.
-docker-compose run server yarn authx schema
+docker-compose run --rm server yarn authx schema
 
 # Populate the database with fixed sample data.
-docker-compose run server yarn authx fixture
+docker-compose run --rm server yarn authx fixture
 ```
 
 Docker will have read and write access to the project directory, but will mount its own copy of the `node_modules` directory. This allows different natively combiled dependencies to be used inside the containers and on the host for scripts/IDEs.
@@ -41,10 +41,10 @@ The `server` service in docker-compose is an ideal place for running tests, eith
 
 ```bash
 # Run the entire test suite.
-docker-compose run server yarn test
+docker-compose run --rm server yarn test
 
 # Run a bash container and execute tests in a specific package.
-docker-compose run server bash
+docker-compose run --rm server bash
 cd packages/scopes
 yarn test
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
         target: /var/lib/postgres
     ports:
       - target: 5432
-        published: "${PUBLISH_PORT_POSTGRES}"
+        published: ${PUBLISH_PORT_POSTGRES}
         protocol: tcp
         mode: host
 
@@ -75,6 +75,6 @@ services:
         target: /workspace/node_modules
     ports:
       - target: 80
-        published: "${PUBLISH_PORT_HTTP}"
+        published: ${PUBLISH_PORT_HTTP}
         protocol: tcp
         mode: host

--- a/packages/authx/src/graphql/mutation/createRoles.ts
+++ b/packages/authx/src/graphql/mutation/createRoles.ts
@@ -6,7 +6,7 @@ import { GraphQLFieldConfig, GraphQLList, GraphQLNonNull } from "graphql";
 import { Context } from "../../Context";
 import { GraphQLRole } from "../GraphQLRole";
 import { Role } from "../../model";
-import { DataLoaderExecutor, ReadonlyDataLoaderExecutor } from "../../loader";
+import { DataLoaderExecutor } from "../../loader";
 import { validateIdFormat } from "../../util/validateIdFormat";
 import { createV2AuthXScope } from "../../util/scopes";
 import {
@@ -45,21 +45,23 @@ export const createRoles: GraphQLFieldConfig<
     },
   },
   async resolve(source, args, context): Promise<Promise<Role>[]> {
-    const { executor, authorization: a, realm } = context;
+    const {
+      executor: { strategies, connection: pool },
+      authorization: a,
+      realm,
+    } = context;
 
     if (!a) {
       throw new ForbiddenError("You must be authenticated to create a role.");
     }
 
-    const strategies = executor.strategies;
-    const pool = executor.connection;
     if (!(pool instanceof Pool)) {
       throw new Error(
         "INVARIANT: The executor connection is expected to be an instance of Pool."
       );
     }
 
-    return args.roles.map(async (input) => {
+    const results = args.roles.map(async (input) => {
       // Validate `id`.
       if (typeof input.id === "string" && !validateIdFormat(input.id)) {
         throw new ValidationError("The provided `id` is an invalid ID.");
@@ -304,11 +306,6 @@ export const createRoles: GraphQLFieldConfig<
           Role.clear(executor, role.id);
           Role.prime(executor, role.id, role);
 
-          // Update the context to use a new executor primed with the results of
-          // this mutation, using the original connection pool.
-          executor.connection = pool;
-          context.executor = executor as ReadonlyDataLoaderExecutor<Pool>;
-
           return role;
         } catch (error) {
           await tx.query("ROLLBACK");
@@ -318,5 +315,13 @@ export const createRoles: GraphQLFieldConfig<
         tx.release();
       }
     });
+
+    // Wait for all mutations to succeed or fail.
+    await Promise.allSettled(results);
+
+    // Set a new executor (clearing all memoized values).
+    context.executor = new DataLoaderExecutor<Pool>(pool, strategies);
+
+    return results;
   },
 };

--- a/packages/authx/src/graphql/mutation/updateGrants.ts
+++ b/packages/authx/src/graphql/mutation/updateGrants.ts
@@ -5,7 +5,7 @@ import { GraphQLFieldConfig, GraphQLList, GraphQLNonNull } from "graphql";
 import { Context } from "../../Context";
 import { GraphQLGrant } from "../GraphQLGrant";
 import { Grant } from "../../model";
-import { DataLoaderExecutor, ReadonlyDataLoaderExecutor } from "../../loader";
+import { DataLoaderExecutor } from "../../loader";
 import { validateIdFormat } from "../../util/validateIdFormat";
 import { ForbiddenError, ValidationError } from "../../errors";
 import { GraphQLUpdateGrantInput } from "./GraphQLUpdateGrantInput";
@@ -35,21 +35,24 @@ export const updateGrants: GraphQLFieldConfig<
     },
   },
   async resolve(source, args, context): Promise<Promise<Grant>[]> {
-    const { executor, authorization: a, realm, codeValidityDuration } = context;
+    const {
+      executor: { strategies, connection: pool },
+      authorization: a,
+      realm,
+      codeValidityDuration,
+    } = context;
 
     if (!a) {
       throw new ForbiddenError("You must be authenticated to update a grant.");
     }
 
-    const strategies = executor.strategies;
-    const pool = executor.connection;
     if (!(pool instanceof Pool)) {
       throw new Error(
         "INVARIANT: The executor connection is expected to be an instance of Pool."
       );
     }
 
-    return args.grants.map(async (input) => {
+    const results = args.grants.map(async (input) => {
       // Validate `id`.
       if (!validateIdFormat(input.id)) {
         throw new ValidationError("The provided `id` is an invalid ID.");
@@ -191,11 +194,6 @@ export const updateGrants: GraphQLFieldConfig<
         Grant.clear(executor, grant.id);
         Grant.prime(executor, grant.id, grant);
 
-        // Update the context to use a new executor primed with the results of
-        // this mutation, using the original connection pool.
-        executor.connection = pool;
-        context.executor = executor as ReadonlyDataLoaderExecutor<Pool>;
-
         return grant;
       } catch (error) {
         await tx.query("ROLLBACK");
@@ -204,5 +202,13 @@ export const updateGrants: GraphQLFieldConfig<
         tx.release();
       }
     });
+
+    // Wait for all mutations to succeed or fail.
+    await Promise.allSettled(results);
+
+    // Set a new executor (clearing all memoized values).
+    context.executor = new DataLoaderExecutor<Pool>(pool, strategies);
+
+    return results;
   },
 };

--- a/packages/authx/src/graphql/mutation/updateRoles.ts
+++ b/packages/authx/src/graphql/mutation/updateRoles.ts
@@ -5,7 +5,7 @@ import { GraphQLFieldConfig, GraphQLList, GraphQLNonNull } from "graphql";
 import { Context } from "../../Context";
 import { GraphQLRole } from "../GraphQLRole";
 import { Role } from "../../model";
-import { DataLoaderExecutor, ReadonlyDataLoaderExecutor } from "../../loader";
+import { DataLoaderExecutor } from "../../loader";
 import { filter } from "../../util/filter";
 import { validateIdFormat } from "../../util/validateIdFormat";
 import { ForbiddenError, ValidationError } from "../../errors";
@@ -36,21 +36,23 @@ export const updateRoles: GraphQLFieldConfig<
     },
   },
   async resolve(source, args, context): Promise<Promise<Role>[]> {
-    const { executor, authorization: a, realm } = context;
+    const {
+      executor: { strategies, connection: pool },
+      authorization: a,
+      realm,
+    } = context;
 
     if (!a) {
       throw new ForbiddenError("You must be authenticated to update a role.");
     }
 
-    const strategies = executor.strategies;
-    const pool = executor.connection;
     if (!(pool instanceof Pool)) {
       throw new Error(
         "INVARIANT: The executor connection is expected to be an instance of Pool."
       );
     }
 
-    return args.roles.map(async (input) => {
+    const results = args.roles.map(async (input) => {
       // Validate `id`.
       if (!validateIdFormat(input.id)) {
         throw new ValidationError("The provided `id` is an invalid ID.");
@@ -193,11 +195,6 @@ export const updateRoles: GraphQLFieldConfig<
         Role.clear(executor, role.id);
         Role.prime(executor, role.id, role);
 
-        // Update the context to use a new executor primed with the results of
-        // this mutation, using the original connection pool.
-        executor.connection = pool;
-        context.executor = executor as ReadonlyDataLoaderExecutor<Pool>;
-
         return role;
       } catch (error) {
         await tx.query("ROLLBACK");
@@ -206,5 +203,13 @@ export const updateRoles: GraphQLFieldConfig<
         tx.release();
       }
     });
+
+    // Wait for all mutations to succeed or fail.
+    await Promise.allSettled(results);
+
+    // Set a new executor (clearing all memoized values).
+    context.executor = new DataLoaderExecutor<Pool>(pool, strategies);
+
+    return results;
   },
 };

--- a/packages/strategy-openid/src/server/graphql/mutation/createOpenIdAuthorities.ts
+++ b/packages/strategy-openid/src/server/graphql/mutation/createOpenIdAuthorities.ts
@@ -59,7 +59,11 @@ export const createOpenIdAuthorities: GraphQLFieldConfig<
     },
   },
   async resolve(source, args, context): Promise<Promise<OpenIdAuthority>[]> {
-    const { executor, authorization: a, realm } = context;
+    const {
+      executor: { strategies, connection: pool },
+      authorization: a,
+      realm,
+    } = context;
 
     if (!a) {
       throw new ForbiddenError(
@@ -67,15 +71,13 @@ export const createOpenIdAuthorities: GraphQLFieldConfig<
       );
     }
 
-    const strategies = executor.strategies;
-    const pool = executor.connection;
     if (!(pool instanceof Pool)) {
       throw new Error(
         "INVARIANT: The executor connection is expected to be an instance of Pool."
       );
     }
 
-    return args.authorities.map(async (input) => {
+    const results = args.authorities.map(async (input) => {
       // Validate `id`.
       if (typeof input.id === "string" && !validateIdFormat(input.id)) {
         throw new ValidationError("The provided `id` is an invalid ID.");
@@ -230,11 +232,6 @@ export const createOpenIdAuthorities: GraphQLFieldConfig<
           Authority.clear(executor, authority.id);
           Authority.prime(executor, authority.id, authority);
 
-          // Update the context to use a new executor primed with the results of
-          // this mutation, using the original connection pool.
-          executor.connection = pool;
-          context.executor = executor as DataLoaderExecutor<Pool>;
-
           return authority;
         } catch (error) {
           await tx.query("ROLLBACK");
@@ -244,5 +241,13 @@ export const createOpenIdAuthorities: GraphQLFieldConfig<
         tx.release();
       }
     });
+
+    // Wait for all mutations to succeed or fail.
+    await Promise.allSettled(results);
+
+    // Set a new executor (clearing all memoized values).
+    context.executor = new DataLoaderExecutor<Pool>(pool, strategies);
+
+    return results;
   },
 };

--- a/packages/strategy-openid/src/server/graphql/mutation/createOpenIdCredentials.ts
+++ b/packages/strategy-openid/src/server/graphql/mutation/createOpenIdCredentials.ts
@@ -17,7 +17,6 @@ import {
   Role,
   validateIdFormat,
   DataLoaderExecutor,
-  ReadonlyDataLoaderExecutor,
 } from "@authx/authx";
 
 import {
@@ -58,7 +57,12 @@ export const createOpenIdCredentials: GraphQLFieldConfig<
     },
   },
   async resolve(source, args, context): Promise<Promise<OpenIdCredential>[]> {
-    const { executor, authorization: a, realm, base } = context;
+    const {
+      executor: { strategies, connection: pool },
+      authorization: a,
+      realm,
+      base,
+    } = context;
 
     if (!a) {
       throw new ForbiddenError(
@@ -66,15 +70,13 @@ export const createOpenIdCredentials: GraphQLFieldConfig<
       );
     }
 
-    const strategies = executor.strategies;
-    const pool = executor.connection;
     if (!(pool instanceof Pool)) {
       throw new Error(
         "INVARIANT: The executor connection is expected to be an instance of Pool."
       );
     }
 
-    return args.credentials.map(async (input) => {
+    const results = args.credentials.map(async (input) => {
       // Validate `id`.
       if (typeof input.id === "string" && !validateIdFormat(input.id)) {
         throw new ValidationError("The provided `id` is an invalid ID.");
@@ -429,11 +431,6 @@ export const createOpenIdCredentials: GraphQLFieldConfig<
         Credential.clear(executor, credential.id);
         Credential.prime(executor, credential.id, credential);
 
-        // Update the context to use a new executor primed with the results of
-        // this mutation, using the original connection pool.
-        executor.connection = pool;
-        context.executor = executor as ReadonlyDataLoaderExecutor<Pool>;
-
         return credential;
       } catch (error) {
         await tx.query("ROLLBACK");
@@ -442,5 +439,13 @@ export const createOpenIdCredentials: GraphQLFieldConfig<
         tx.release();
       }
     });
+
+    // Wait for all mutations to succeed or fail.
+    await Promise.allSettled(results);
+
+    // Set a new executor (clearing all memoized values).
+    context.executor = new DataLoaderExecutor<Pool>(pool, strategies);
+
+    return results;
   },
 };

--- a/packages/strategy-openid/src/server/graphql/mutation/updateOpenIdAuthorities.ts
+++ b/packages/strategy-openid/src/server/graphql/mutation/updateOpenIdAuthorities.ts
@@ -10,7 +10,6 @@ import {
   ValidationError,
   validateIdFormat,
   DataLoaderExecutor,
-  ReadonlyDataLoaderExecutor,
 } from "@authx/authx";
 import { OpenIdAuthority } from "../../model";
 import { GraphQLOpenIdAuthority } from "../GraphQLOpenIdAuthority";
@@ -47,7 +46,11 @@ export const updateOpenIdAuthorities: GraphQLFieldConfig<
     },
   },
   async resolve(source, args, context): Promise<Promise<OpenIdAuthority>[]> {
-    const { executor, authorization: a, realm } = context;
+    const {
+      executor: { strategies, connection: pool },
+      authorization: a,
+      realm,
+    } = context;
 
     if (!a) {
       throw new ForbiddenError(
@@ -55,15 +58,13 @@ export const updateOpenIdAuthorities: GraphQLFieldConfig<
       );
     }
 
-    const strategies = executor.strategies;
-    const pool = executor.connection;
     if (!(pool instanceof Pool)) {
       throw new Error(
         "INVARIANT: The executor connection is expected to be an instance of Pool."
       );
     }
 
-    return args.authorities.map(async (input) => {
+    const results = args.authorities.map(async (input) => {
       // Validate `id`.
       if (!validateIdFormat(input.id)) {
         throw new ValidationError("The provided `id` is an invalid ID.");
@@ -189,11 +190,6 @@ export const updateOpenIdAuthorities: GraphQLFieldConfig<
         Authority.clear(executor, authority.id);
         Authority.prime(executor, authority.id, authority);
 
-        // Update the context to use a new executor primed with the results of
-        // this mutation, using the original connection pool.
-        executor.connection = pool;
-        context.executor = executor as ReadonlyDataLoaderExecutor<Pool>;
-
         return authority;
       } catch (error) {
         await tx.query("ROLLBACK");
@@ -202,5 +198,13 @@ export const updateOpenIdAuthorities: GraphQLFieldConfig<
         tx.release();
       }
     });
+
+    // Wait for all mutations to succeed or fail.
+    await Promise.allSettled(results);
+
+    // Set a new executor (clearing all memoized values).
+    context.executor = new DataLoaderExecutor<Pool>(pool, strategies);
+
+    return results;
   },
 };

--- a/packages/strategy-openid/src/server/graphql/mutation/updateOpenIdCredentials.ts
+++ b/packages/strategy-openid/src/server/graphql/mutation/updateOpenIdCredentials.ts
@@ -10,7 +10,6 @@ import {
   ValidationError,
   validateIdFormat,
   DataLoaderExecutor,
-  ReadonlyDataLoaderExecutor,
 } from "@authx/authx";
 import { OpenIdCredential } from "../../model";
 import { GraphQLOpenIdCredential } from "../GraphQLOpenIdCredential";
@@ -36,7 +35,11 @@ export const updateOpenIdCredentials: GraphQLFieldConfig<
     },
   },
   async resolve(source, args, context): Promise<Promise<OpenIdCredential>[]> {
-    const { executor, authorization: a, realm } = context;
+    const {
+      executor: { strategies, connection: pool },
+      authorization: a,
+      realm,
+    } = context;
 
     if (!a) {
       throw new ForbiddenError(
@@ -44,15 +47,13 @@ export const updateOpenIdCredentials: GraphQLFieldConfig<
       );
     }
 
-    const strategies = executor.strategies;
-    const pool = executor.connection;
     if (!(pool instanceof Pool)) {
       throw new Error(
         "INVARIANT: The executor connection is expected to be an instance of Pool."
       );
     }
 
-    return args.credentials.map(async (input) => {
+    const results = args.credentials.map(async (input) => {
       // Validate `id`.
       if (!validateIdFormat(input.id)) {
         throw new ValidationError("The provided `id` is an invalid ID.");
@@ -109,11 +110,6 @@ export const updateOpenIdCredentials: GraphQLFieldConfig<
         Credential.clear(executor, credential.id);
         Credential.prime(executor, credential.id, credential);
 
-        // Update the context to use a new executor primed with the results of
-        // this mutation, using the original connection pool.
-        executor.connection = pool;
-        context.executor = executor as ReadonlyDataLoaderExecutor<Pool>;
-
         return credential;
       } catch (error) {
         await tx.query("ROLLBACK");
@@ -122,5 +118,13 @@ export const updateOpenIdCredentials: GraphQLFieldConfig<
         tx.release();
       }
     });
+
+    // Wait for all mutations to succeed or fail.
+    await Promise.allSettled(results);
+
+    // Set a new executor (clearing all memoized values).
+    context.executor = new DataLoaderExecutor<Pool>(pool, strategies);
+
+    return results;
   },
 };

--- a/packages/strategy-password/src/server/graphql/mutation/createPasswordAuthorities.ts
+++ b/packages/strategy-password/src/server/graphql/mutation/createPasswordAuthorities.ts
@@ -51,7 +51,11 @@ export const createPasswordAuthorities: GraphQLFieldConfig<
     },
   },
   async resolve(source, args, context): Promise<Promise<PasswordAuthority>[]> {
-    const { executor, authorization: a, realm } = context;
+    const {
+      executor: { strategies, connection: pool },
+      authorization: a,
+      realm,
+    } = context;
 
     if (!a) {
       throw new ForbiddenError(
@@ -59,15 +63,13 @@ export const createPasswordAuthorities: GraphQLFieldConfig<
       );
     }
 
-    const strategies = executor.strategies;
-    const pool = executor.connection;
     if (!(pool instanceof Pool)) {
       throw new Error(
         "INVARIANT: The executor connection is expected to be an instance of Pool."
       );
     }
 
-    return args.authorities.map(async (input) => {
+    const results = args.authorities.map(async (input) => {
       // Validate `id`.
       if (typeof input.id === "string" && !validateIdFormat(input.id)) {
         throw new ValidationError("The provided `id` is an invalid ID.");
@@ -212,11 +214,6 @@ export const createPasswordAuthorities: GraphQLFieldConfig<
           Authority.clear(executor, authority.id);
           Authority.prime(executor, authority.id, authority);
 
-          // Update the context to use a new executor primed with the results of
-          // this mutation, using the original connection pool.
-          executor.connection = pool;
-          context.executor = executor as DataLoaderExecutor<Pool>;
-
           return authority;
         } catch (error) {
           await tx.query("ROLLBACK");
@@ -226,5 +223,13 @@ export const createPasswordAuthorities: GraphQLFieldConfig<
         tx.release();
       }
     });
+
+    // Wait for all mutations to succeed or fail.
+    await Promise.allSettled(results);
+
+    // Set a new executor (clearing all memoized values).
+    context.executor = new DataLoaderExecutor<Pool>(pool, strategies);
+
+    return results;
   },
 };

--- a/packages/strategy-password/src/server/graphql/mutation/updatePasswordAuthorities.ts
+++ b/packages/strategy-password/src/server/graphql/mutation/updatePasswordAuthorities.ts
@@ -10,7 +10,6 @@ import {
   ValidationError,
   validateIdFormat,
   DataLoaderExecutor,
-  ReadonlyDataLoaderExecutor,
 } from "@authx/authx";
 import { PasswordAuthority } from "../../model";
 import { GraphQLPasswordAuthority } from "../GraphQLPasswordAuthority";
@@ -39,7 +38,11 @@ export const updatePasswordAuthorities: GraphQLFieldConfig<
     },
   },
   async resolve(source, args, context): Promise<Promise<PasswordAuthority>[]> {
-    const { executor, authorization: a, realm } = context;
+    const {
+      executor: { strategies, connection: pool },
+      authorization: a,
+      realm,
+    } = context;
 
     if (!a) {
       throw new ForbiddenError(
@@ -47,15 +50,13 @@ export const updatePasswordAuthorities: GraphQLFieldConfig<
       );
     }
 
-    const strategies = executor.strategies;
-    const pool = executor.connection;
     if (!(pool instanceof Pool)) {
       throw new Error(
         "INVARIANT: The executor connection is expected to be an instance of Pool."
       );
     }
 
-    return args.authorities.map(async (input) => {
+    const results = args.authorities.map(async (input) => {
       // Validate `id`.
       if (!validateIdFormat(input.id)) {
         throw new ValidationError("The provided `id` is an invalid ID.");
@@ -136,11 +137,6 @@ export const updatePasswordAuthorities: GraphQLFieldConfig<
         Authority.clear(executor, authority.id);
         Authority.prime(executor, authority.id, authority);
 
-        // Update the context to use a new executor primed with the results of
-        // this mutation, using the original connection pool.
-        executor.connection = pool;
-        context.executor = executor as ReadonlyDataLoaderExecutor<Pool>;
-
         return authority;
       } catch (error) {
         await tx.query("ROLLBACK");
@@ -149,5 +145,13 @@ export const updatePasswordAuthorities: GraphQLFieldConfig<
         tx.release();
       }
     });
+
+    // Wait for all mutations to succeed or fail.
+    await Promise.allSettled(results);
+
+    // Set a new executor (clearing all memoized values).
+    context.executor = new DataLoaderExecutor<Pool>(pool, strategies);
+
+    return results;
   },
 };

--- a/packages/strategy-saml/src/server/graphql/mutation/createSamlAuthorities.ts
+++ b/packages/strategy-saml/src/server/graphql/mutation/createSamlAuthorities.ts
@@ -52,7 +52,11 @@ export const createSamlAuthorities: GraphQLFieldConfig<
     },
   },
   async resolve(source, args, context): Promise<Promise<SamlAuthority>[]> {
-    const { executor, authorization: a, realm } = context;
+    const {
+      executor: { strategies, connection: pool },
+      authorization: a,
+      realm,
+    } = context;
 
     if (!a) {
       throw new ForbiddenError(
@@ -60,15 +64,13 @@ export const createSamlAuthorities: GraphQLFieldConfig<
       );
     }
 
-    const strategies = executor.strategies;
-    const pool = executor.connection;
     if (!(pool instanceof Pool)) {
       throw new Error(
         "INVARIANT: The executor connection is expected to be an instance of Pool."
       );
     }
 
-    return args.authorities.map(async (input) => {
+    const results = args.authorities.map(async (input) => {
       // Validate `id`.
       if (typeof input.id === "string" && !validateIdFormat(input.id)) {
         throw new ValidationError("The provided `id` is an invalid ID.");
@@ -223,11 +225,6 @@ export const createSamlAuthorities: GraphQLFieldConfig<
           Authority.clear(executor, authority.id);
           Authority.prime(executor, authority.id, authority);
 
-          // Update the context to use a new executor primed with the results of
-          // this mutation, using the original connection pool.
-          executor.connection = pool;
-          context.executor = executor as DataLoaderExecutor<Pool>;
-
           return authority;
         } catch (error) {
           await tx.query("ROLLBACK");
@@ -237,5 +234,13 @@ export const createSamlAuthorities: GraphQLFieldConfig<
         tx.release();
       }
     });
+
+    // Wait for all mutations to succeed or fail.
+    await Promise.allSettled(results);
+
+    // Set a new executor (clearing all memoized values).
+    context.executor = new DataLoaderExecutor<Pool>(pool, strategies);
+
+    return results;
   },
 };

--- a/packages/strategy-saml/src/server/graphql/mutation/updateSamlAuthorities.ts
+++ b/packages/strategy-saml/src/server/graphql/mutation/updateSamlAuthorities.ts
@@ -8,7 +8,6 @@ import {
   DataLoaderExecutor,
   ForbiddenError,
   NotFoundError,
-  ReadonlyDataLoaderExecutor,
   validateIdFormat,
   ValidationError,
 } from "@authx/authx";
@@ -51,7 +50,11 @@ export const updateSamlAuthorities: GraphQLFieldConfig<
     },
   },
   async resolve(source, args, context): Promise<Promise<SamlAuthority>[]> {
-    const { executor, authorization: a, realm } = context;
+    const {
+      executor: { strategies, connection: pool },
+      authorization: a,
+      realm,
+    } = context;
 
     if (!a) {
       throw new ForbiddenError(
@@ -59,15 +62,13 @@ export const updateSamlAuthorities: GraphQLFieldConfig<
       );
     }
 
-    const strategies = executor.strategies;
-    const pool = executor.connection;
     if (!(pool instanceof Pool)) {
       throw new Error(
         "INVARIANT: The executor connection is expected to be an instance of Pool."
       );
     }
 
-    return args.authorities.map(async (input) => {
+    const results = args.authorities.map(async (input) => {
       // Validate `id`.
       if (!validateIdFormat(input.id)) {
         throw new ValidationError("The provided `id` is an invalid ID.");
@@ -200,11 +201,6 @@ export const updateSamlAuthorities: GraphQLFieldConfig<
         Authority.clear(executor, authority.id);
         Authority.prime(executor, authority.id, authority);
 
-        // Update the context to use a new executor primed with the results of
-        // this mutation, using the original connection pool.
-        executor.connection = pool;
-        context.executor = executor as ReadonlyDataLoaderExecutor<Pool>;
-
         return authority;
       } catch (error) {
         await tx.query("ROLLBACK");
@@ -213,5 +209,13 @@ export const updateSamlAuthorities: GraphQLFieldConfig<
         tx.release();
       }
     });
+
+    // Wait for all mutations to succeed or fail.
+    await Promise.allSettled(results);
+
+    // Set a new executor (clearing all memoized values).
+    context.executor = new DataLoaderExecutor<Pool>(pool, strategies);
+
+    return results;
   },
 };

--- a/packages/strategy-saml/src/server/graphql/mutation/updateSamlCredentials.ts
+++ b/packages/strategy-saml/src/server/graphql/mutation/updateSamlCredentials.ts
@@ -8,7 +8,6 @@ import {
   DataLoaderExecutor,
   ForbiddenError,
   NotFoundError,
-  ReadonlyDataLoaderExecutor,
   validateIdFormat,
   ValidationError,
 } from "@authx/authx";
@@ -36,7 +35,11 @@ export const updateSamlCredentials: GraphQLFieldConfig<
     },
   },
   async resolve(source, args, context): Promise<Promise<SamlCredential>[]> {
-    const { executor, authorization: a, realm } = context;
+    const {
+      executor: { strategies, connection: pool },
+      authorization: a,
+      realm,
+    } = context;
 
     if (!a) {
       throw new ForbiddenError(
@@ -44,15 +47,13 @@ export const updateSamlCredentials: GraphQLFieldConfig<
       );
     }
 
-    const strategies = executor.strategies;
-    const pool = executor.connection;
     if (!(pool instanceof Pool)) {
       throw new Error(
         "INVARIANT: The executor connection is expected to be an instance of Pool."
       );
     }
 
-    return args.credentials.map(async (input) => {
+    const results = args.credentials.map(async (input) => {
       // Validate `id`.
       if (!validateIdFormat(input.id)) {
         throw new ValidationError("The provided `id` is an invalid ID.");
@@ -109,11 +110,6 @@ export const updateSamlCredentials: GraphQLFieldConfig<
         Credential.clear(executor, credential.id);
         Credential.prime(executor, credential.id, credential);
 
-        // Update the context to use a new executor primed with the results of
-        // this mutation, using the original connection pool.
-        executor.connection = pool;
-        context.executor = executor as ReadonlyDataLoaderExecutor<Pool>;
-
         return credential;
       } catch (error) {
         await tx.query("ROLLBACK");
@@ -122,5 +118,13 @@ export const updateSamlCredentials: GraphQLFieldConfig<
         tx.release();
       }
     });
+
+    // Wait for all mutations to succeed or fail.
+    await Promise.allSettled(results);
+
+    // Set a new executor (clearing all memoized values).
+    context.executor = new DataLoaderExecutor<Pool>(pool, strategies);
+
+    return results;
   },
 };


### PR DESCRIPTION
Make sure that all create/update mutations that accept multiple objects modify them individually and set a fresh executor at the end.

Also fixes a bug in createAuthorizations where multiple subsequent authorizations would be inserted outside a transaction.