### PR TITLE
remove default from UpdateRoleInput.enabled

### DIFF
--- a/packages/authx/src/graphql/mutation/GraphQLUpdateRoleInput.ts
+++ b/packages/authx/src/graphql/mutation/GraphQLUpdateRoleInput.ts
@@ -17,7 +17,6 @@ export const GraphQLUpdateRoleInput = new GraphQLInputObjectType({
     },
     enabled: {
       type: GraphQLBoolean,
-      defaultValue: true,
     },
     name: {
       type: GraphQLString,

--- a/packages/authx/src/graphql/mutation/updateRoles.ts
+++ b/packages/authx/src/graphql/mutation/updateRoles.ts
@@ -17,7 +17,7 @@ export const updateRoles: GraphQLFieldConfig<
   {
     roles: {
       id: string;
-      enabled: boolean;
+      enabled: null | boolean;
       name: null | string;
       description: null | string;
       scopes: null | string[];


### PR DESCRIPTION
This caused updates of disabled roles over the API to become reenabled when the field was omitted from the request.