### PR TITLE
Normalize access from disabled entities

### DIFF
--- a/packages/authx/src/model/Grant.ts
+++ b/packages/authx/src/model/Grant.ts
@@ -166,10 +166,16 @@ export class Grant implements GrantData {
       currentClientId: null | string;
     }
   ): Promise<string[]> {
+    if (!this.enabled) {
+      return [];
+    }
+
     const user = await this.user(tx);
-    return user.enabled
-      ? getIntersection(this.scopes, await user.access(tx, values))
-      : [];
+    if (!user.enabled) {
+      return [];
+    }
+
+    return getIntersection(this.scopes, await user.access(tx, values));
   }
 
   public async can(

--- a/packages/authx/src/model/Role.ts
+++ b/packages/authx/src/model/Role.ts
@@ -103,6 +103,10 @@ export class Role implements RoleData {
     currentGrantId: null | string;
     currentClientId: null | string;
   }): string[] {
+    if (!this.enabled) {
+      return [];
+    }
+
     return inject(this.scopes, {
       /* eslint-disable camelcase */
       current_authorization_id: values.currentAuthorizationId,

--- a/packages/authx/src/model/User.ts
+++ b/packages/authx/src/model/User.ts
@@ -252,13 +252,16 @@ export class User implements UserData {
       currentClientId: null | string;
     }
   ): Promise<string[]> {
-    return this.enabled
-      ? simplify(
-          (await this.roles(tx))
-            .map((role) => role.access(values))
-            .reduce((a, b) => a.concat(b), [])
-        )
-      : [];
+    if (!this.enabled) {
+      return [];
+    }
+
+    return simplify(
+      (await this.roles(tx))
+        .filter((role) => role.enabled)
+        .map((role) => role.access(values))
+        .reduce((a, b) => a.concat(b), [])
+    );
   }
 
   public async can(

--- a/packages/authx/src/util/getAuthorization.ts
+++ b/packages/authx/src/util/getAuthorization.ts
@@ -37,7 +37,7 @@ export async function fromBasic(
         : undefined
     );
 
-  const grant = await authorization.user(tx);
+  const grant = await authorization.grant(tx);
   if (grant && !grant.enabled)
     throw new AuthenticationError(
       __DEV__
@@ -112,7 +112,7 @@ export async function fromBearer(
         : undefined
     );
 
-  const grant = await authorization.user(tx);
+  const grant = await authorization.grant(tx);
   if (grant && !grant.enabled)
     throw new AuthenticationError(
       __DEV__

--- a/packages/tools/src/lib/fixture/authorization.ts
+++ b/packages/tools/src/lib/fixture/authorization.ts
@@ -68,4 +68,70 @@ export const authorization = [
         }
       ),
   },
+  {
+    id: "6d648342-5b7b-4aaf-8924-3ae3bf54966d",
+    insert: (tx: ClientBase): Promise<Authorization> =>
+      Authorization.write(
+        tx,
+        {
+          id: "6d648342-5b7b-4aaf-8924-3ae3bf54966d",
+          enabled: true,
+          userId: "dc396449-2c7d-4a23-a159-e6415ded71d2",
+          grantId: null,
+          secret:
+            "49903234add7ffb86d54be39e99e4c128a70d718317d78c9198ee041ab9109b7",
+          scopes: ["**:**:**"],
+        },
+        {
+          recordId: "6b942955-60c5-468c-b3fc-d321fb7095ee",
+          createdByAuthorizationId: "f0e54748-c7bb-4724-ad8b-7dabb66aafa9",
+          createdByCredentialId: null,
+          createdAt: new Date("2019-03-06T21:07:59.814Z"),
+        }
+      ),
+  },
+  {
+    id: "9883c6dc-7480-49d8-ae70-d50aab59205d",
+    insert: (tx: ClientBase): Promise<Authorization> =>
+      Authorization.write(
+        tx,
+        {
+          id: "9883c6dc-7480-49d8-ae70-d50aab59205d",
+          enabled: true,
+          userId: "306eabbb-cc2b-4f88-be19-4bb6ec98e5c3",
+          grantId: "3fc15344-13f6-4863-91e9-c8ab09cfb4b7",
+          secret:
+            "bf5224549f5b9c3264ebb296827e76938be7c8fe34080d67acb08d5aea89e0db",
+          scopes: ["**:**:**"],
+        },
+        {
+          recordId: "2a6ae2b0-b3f0-4401-b29a-4e5ba24684d8",
+          createdByAuthorizationId: "f0e54748-c7bb-4724-ad8b-7dabb66aafa9",
+          createdByCredentialId: null,
+          createdAt: new Date("2019-03-06T21:07:59.814Z"),
+        }
+      ),
+  },
+  {
+    id: "5de5d381-6257-4930-863b-5517402a67f7",
+    insert: (tx: ClientBase): Promise<Authorization> =>
+      Authorization.write(
+        tx,
+        {
+          id: "5de5d381-6257-4930-863b-5517402a67f7",
+          enabled: false,
+          userId: "306eabbb-cc2b-4f88-be19-4bb6ec98e5c3",
+          grantId: null,
+          secret:
+            "f3251a35903ae20208602bb38d5209c247d020d616a3e1d1a6109e009f4590d6",
+          scopes: ["**:**:**"],
+        },
+        {
+          recordId: "1dfcc20d-ab1d-47a2-a171-180d957f2425",
+          createdByAuthorizationId: "f0e54748-c7bb-4724-ad8b-7dabb66aafa9",
+          createdByCredentialId: null,
+          createdAt: new Date("2019-03-06T21:07:59.814Z"),
+        }
+      ),
+  },
 ];

--- a/packages/tools/src/lib/fixture/grant.ts
+++ b/packages/tools/src/lib/fixture/grant.ts
@@ -73,4 +73,29 @@ export const grant = [
         }
       ),
   },
+  {
+    id: "3fc15344-13f6-4863-91e9-c8ab09cfb4b7",
+    insert: (tx: ClientBase): Promise<Grant> =>
+      Grant.write(
+        tx,
+        {
+          id: "3fc15344-13f6-4863-91e9-c8ab09cfb4b7",
+          enabled: false,
+          clientId: "17436d83-6022-4101-bf9f-997f1550f57c",
+          userId: "306eabbb-cc2b-4f88-be19-4bb6ec98e5c3",
+          secrets: [
+            "M2ZjMTUzNDQtMTNmNi00ODYzLTkxZTktYzhhYjA5Y2ZiNGI3OjE1NTM5MjUzNDA6ZDE3ZGM0OTlhMmFjNDIzNWEwNTZjZTEyNGNmZGUxM2M=",
+          ],
+          codes: [
+            "M2ZjMTUzNDQtMTNmNi00ODYzLTkxZTktYzhhYjA5Y2ZiNGI3OjE1NTM5MjUzNDA6MzY5NGU0YmE2NzljNDAyNWFhNjJiMjdmZWI2NGM5MWE=",
+          ],
+          scopes: ["**:**:**"],
+        },
+        {
+          recordId: "0af9a524-88e6-47f1-bbfa-c9c749075bc6",
+          createdByAuthorizationId: "f0e54748-c7bb-4724-ad8b-7dabb66aafa9",
+          createdAt: new Date("2019-03-06T21:07:59.814Z"),
+        }
+      ),
+  },
 ];

--- a/src/disabled.test.ts
+++ b/src/disabled.test.ts
@@ -1,0 +1,198 @@
+import test from "ava";
+import fetch from "node-fetch";
+import { URL } from "url";
+import { setup } from "./setup";
+import { basename } from "path";
+
+let url: URL;
+let teardown: () => Promise<void>;
+
+// Setup.
+test.before(async () => {
+  const s = await setup(basename(__filename, ".js"));
+  url = s.url;
+  teardown = s.teardown;
+});
+
+test("Authorization of disabled user cannot be used.", async (t) => {
+  const graphqlUrl = new URL(url.href);
+  graphqlUrl.pathname = "/graphql";
+
+  const result = await fetch(graphqlUrl.href, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization:
+        "Basic NmQ2NDgzNDItNWI3Yi00YWFmLTg5MjQtM2FlM2JmNTQ5NjZkOjQ5OTAzMjM0YWRkN2ZmYjg2ZDU0YmUzOWU5OWU0YzEyOGE3MGQ3MTgzMTdkNzhjOTE5OGVlMDQxYWI5MTA5Yjc=",
+    },
+    body: JSON.stringify({
+      query: /* GraphQL */ `
+        query {
+          viewer {
+            id
+            access
+          }
+        }
+      `,
+    }),
+  });
+
+  const json = await result.json();
+
+  t.deepEqual(
+    {
+      errors: [
+        {
+          message:
+            "The user of the authorization specified in HTTP authorization header is disabled.",
+        },
+      ],
+    },
+    json
+  );
+});
+
+test("Authorization of disabled grant cannot be used.", async (t) => {
+  const graphqlUrl = new URL(url.href);
+  graphqlUrl.pathname = "/graphql";
+
+  const result = await fetch(graphqlUrl.href, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization:
+        "Basic OTg4M2M2ZGMtNzQ4MC00OWQ4LWFlNzAtZDUwYWFiNTkyMDVkOmJmNTIyNDU0OWY1YjljMzI2NGViYjI5NjgyN2U3NjkzOGJlN2M4ZmUzNDA4MGQ2N2FjYjA4ZDVhZWE4OWUwZGI=",
+    },
+    body: JSON.stringify({
+      query: /* GraphQL */ `
+        query {
+          viewer {
+            id
+            access
+          }
+        }
+      `,
+    }),
+  });
+
+  const json = await result.json();
+
+  t.deepEqual(
+    {
+      errors: [
+        {
+          message:
+            "The grant of the authorization specified in HTTP authorization header is disabled.",
+        },
+      ],
+    },
+    json
+  );
+});
+
+test("Disabled authorization cannot be used.", async (t) => {
+  const graphqlUrl = new URL(url.href);
+  graphqlUrl.pathname = "/graphql";
+
+  const result = await fetch(graphqlUrl.href, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization:
+        "Basic NWRlNWQzODEtNjI1Ny00OTMwLTg2M2ItNTUxNzQwMmE2N2Y3OmYzMjUxYTM1OTAzYWUyMDIwODYwMmJiMzhkNTIwOWMyNDdkMDIwZDYxNmEzZTFkMWE2MTA5ZTAwOWY0NTkwZDY=",
+    },
+    body: JSON.stringify({
+      query: /* GraphQL */ `
+        query {
+          viewer {
+            id
+            access
+          }
+        }
+      `,
+    }),
+  });
+
+  const json = await result.json();
+
+  t.deepEqual(
+    {
+      errors: [
+        {
+          message:
+            "The authorization specified in HTTP authorization header is disabled.",
+        },
+      ],
+    },
+    json
+  );
+});
+
+test("Access is revoked from disble authorizations.", async (t) => {
+  const graphqlUrl = new URL(url.href);
+  graphqlUrl.pathname = "/graphql";
+
+  const result = await fetch(graphqlUrl.href, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization:
+        "Basic YzcwZGE0OTgtMjdlZC00YzNiLWEzMTgtMzhiYjIyMGNlZjQ4OjhmNTczOTVlY2Q5ZDZmY2I4ODQxNDVmOGY2ZmVmZjM1N2ZlYWQyZmJkODM2MDdlODdkNzFhN2MzNzJjZjM3YWQ=",
+    },
+    body: JSON.stringify({
+      query: /* GraphQL */ `
+        query {
+          authorizationOfDisabledUser: authorization(
+            id: "6d648342-5b7b-4aaf-8924-3ae3bf54966d"
+          ) {
+            id
+            access
+          }
+
+          authorizationOfDisabledGrant: authorization(
+            id: "9883c6dc-7480-49d8-ae70-d50aab59205d"
+          ) {
+            id
+            access
+          }
+
+          disabledAuthorization: authorization(
+            id: "5de5d381-6257-4930-863b-5517402a67f7"
+          ) {
+            id
+            access
+          }
+        }
+      `,
+    }),
+  });
+
+  const json = await result.json();
+
+  t.deepEqual(
+    {
+      data: {
+        authorizationOfDisabledGrant: {
+          access: [],
+          id: "9883c6dc-7480-49d8-ae70-d50aab59205d",
+        },
+        authorizationOfDisabledUser: {
+          access: [],
+          id: "6d648342-5b7b-4aaf-8924-3ae3bf54966d",
+        },
+        disabledAuthorization: {
+          access: [],
+          id: "5de5d381-6257-4930-863b-5517402a67f7",
+        },
+      },
+    },
+    json
+  );
+});
+
+// Teardown.
+test.after.always(async () => {
+  if (teardown) {
+    await teardown();
+  }
+});

--- a/src/graphql/query/authorizations.test.ts
+++ b/src/graphql/query/authorizations.test.ts
@@ -39,6 +39,7 @@ pagingTests({
   ids: [
     "5387ece5-37a1-4573-a189-14333ebf8d88",
     "f0e54748-c7bb-4724-ad8b-7dabb66aafa9",
+    null,
   ],
   scopes: [
     createReadScope("5387ece5-37a1-4573-a189-14333ebf8d88", "*", "*", "*"),
@@ -53,6 +54,7 @@ pagingTests({
   ids: [
     "5387ece5-37a1-4573-a189-14333ebf8d88",
     "f0e54748-c7bb-4724-ad8b-7dabb66aafa9",
+    null,
   ],
   scopes: [
     createReadScope("*", "*", "*", "e165cbb0-86b0-4e11-9db7-eb5f742161b8"),
@@ -67,6 +69,7 @@ pagingTests({
   ids: [
     "5387ece5-37a1-4573-a189-14333ebf8d88",
     "f0e54748-c7bb-4724-ad8b-7dabb66aafa9",
+    null,
   ],
   scopes: [
     createReadScope("*", "*", "d8dcaf12-b744-4d2d-b223-09e7e5eaa922", "*"),
@@ -78,7 +81,7 @@ pagingTests({
 pagingTests({
   testName: "by client ID with wildcards",
   entityType: "authorization",
-  ids: ["5387ece5-37a1-4573-a189-14333ebf8d88"],
+  ids: ["5387ece5-37a1-4573-a189-14333ebf8d88", null],
   scopes: [
     createReadScope("*", "1fcb730e-f134-463a-b224-cab7e61c5ce0", "*", "*"),
   ],
@@ -88,7 +91,7 @@ pagingTests({
 pagingTests({
   testName: "by client ID",
   entityType: "authorization",
-  ids: ["5387ece5-37a1-4573-a189-14333ebf8d88"],
+  ids: ["5387ece5-37a1-4573-a189-14333ebf8d88", null],
   scopes: [
     "authx:v2.authorization.*.5387ece5-37a1-4573-a189-14333ebf8d88.**:r....",
   ],
@@ -98,7 +101,7 @@ pagingTests({
 pagingTests({
   testName: "by grant and client ID",
   entityType: "authorization",
-  ids: ["5387ece5-37a1-4573-a189-14333ebf8d88"],
+  ids: ["5387ece5-37a1-4573-a189-14333ebf8d88", null],
   scopes: [
     createReadScope(
       "*",

--- a/src/graphql/query/users.test.ts
+++ b/src/graphql/query/users.test.ts
@@ -27,7 +27,7 @@ test("Fetch users with limited read scope and page", async (t) => {
     );
   }
 
-  const token = await ctx.createLimitedAuthorization([
+  const [, token] = await ctx.createLimitedAuthorization([
     createUserReadScope("0cbd3783-0424-4f35-be51-b42f07a2a987"), // Dwight Schrute
     createUserReadScope("51192909-3664-44d5-be62-c6b45f0b0ee6"), // Darryl Philbin
     createUserReadScope("d0fc4c64-a3d6-4d97-9341-07de24439bb1"), // Jim Halpert
@@ -255,7 +255,7 @@ test("Fetch users with limited read scope and reverse page", async (t) => {
     );
   }
 
-  const token = await ctx.createLimitedAuthorization([
+  const [, token] = await ctx.createLimitedAuthorization([
     createUserReadScope("0cbd3783-0424-4f35-be51-b42f07a2a987"), // Dwight Schrute
     createUserReadScope("51192909-3664-44d5-be62-c6b45f0b0ee6"), // Darryl Philbin
     createUserReadScope("d0fc4c64-a3d6-4d97-9341-07de24439bb1"), // Jim Halpert
@@ -473,7 +473,7 @@ test("Fetch users all users scope", async (t) => {
     scopes: "",
   };
 
-  const token = await ctx.createLimitedAuthorization([
+  const [, token] = await ctx.createLimitedAuthorization([
     createV2AuthXScope("authx", clientContext, clientAction),
   ]);
 
@@ -564,7 +564,7 @@ test("Fetch users incorrect scope", async (t) => {
     secrets: "r",
   };
 
-  const token = await ctx.createLimitedAuthorization([
+  const [, token] = await ctx.createLimitedAuthorization([
     createV2AuthXScope("authx", clientContext, clientAction),
   ]);
 


### PR DESCRIPTION
This fixes a few bugs I noticed yesterday around the handling of disabled entities. See the individual commits for more details.

(This would ideally _not_ be squashed when merged, to preserve these distinct commits in history.)