### PR TITLE
Key added to 429 message

### DIFF
--- a/packages/authx/src/util/ratelimiter.ts
+++ b/packages/authx/src/util/ratelimiter.ts
@@ -46,7 +46,7 @@ export class LocalMemoryRateLimiter implements RateLimiter {
       typeof this.map[key] !== "undefined" &&
       this.map[key].length >= this.limitPerWindow
     ) {
-      throw new TooManyRequests();
+      throw new TooManyRequests(`Too many requests for key '${key}'.`);
     }
 
     if (typeof this.map[key] === "undefined") {

--- a/packages/authx/src/util/raterlimiter.test.ts
+++ b/packages/authx/src/util/raterlimiter.test.ts
@@ -27,6 +27,7 @@ test("Rate limiter over rate", async (t) => {
     limiter.limit("A");
     t.fail("4th call in the same minute should cause 429");
   } catch (ex) {
+    t.assert(ex?.message === `Too many requests for key 'A'.`);
     t.pass();
   }
 });


### PR DESCRIPTION
Currently in some cases it's unclear what key caused a 429 error. This change would make it clear.