### PR TITLE
Add request.proxy event

### DIFF
--- a/packages/http-proxy-resource/src/index.ts
+++ b/packages/http-proxy-resource/src/index.ts
@@ -355,6 +355,7 @@ export default class AuthXResourceProxy extends EventEmitter {
       meta.message = "Request proxied." + (warning ? ` (${warning})` : "");
       meta.rule = rule;
       meta.behavior = behavior;
+      this.emit("request.proxy", meta);
       this._proxy.web(request, response, behavior.proxyOptions, (error) => {
         if (!response.headersSent) {
           const code = (error as any).code;


### PR DESCRIPTION
This event provides a mechanism for injecting custom headers into the request or response based on other values present in the `meta` object. The driving use-case here is passing the subject and authorization IDs into the protected endpoints for logging and action attribution purposes.