### PR TITLE
Changed to use new publish command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,4 +75,4 @@ jobs:
           VERSION: ${{ steps.GenerateVersion.outputs.version }}
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc
-          scripts/run-in-packages.sh yarn publish --access public --no-git-tag-version --new-version $VERSION
+          scripts/run-in-packages.sh yarn npm publish --access public --no-git-tag-version --new-version $VERSION

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,11 +14,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@authx/authx@^3.1.0-alpha.35, @authx/authx@workspace:packages/authx":
+"@authx/authx@^3.1.0-alpha.36, @authx/authx@workspace:packages/authx":
   version: 0.0.0-use.local
   resolution: "@authx/authx@workspace:packages/authx"
   dependencies:
-    "@authx/scopes": ^3.1.0-alpha.35
+    "@authx/scopes": ^3.1.0-alpha.36
     "@opencensus/core": ^0.0.22
     "@types/auth-header": ^1.0.1
     "@types/graphql-api-koa": ^2.0.2
@@ -91,7 +91,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@authx/http-proxy-resource@workspace:packages/http-proxy-resource"
   dependencies:
-    "@authx/scopes": ^3.1.0-alpha.35
+    "@authx/scopes": ^3.1.0-alpha.36
     "@types/http-proxy": ^1.17.5
     "@types/jsonwebtoken": ^8.5.1
     "@types/node-fetch": ^2.5.10
@@ -114,7 +114,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@authx/http-proxy-web@workspace:packages/http-proxy-web"
   dependencies:
-    "@authx/scopes": ^3.1.0-alpha.35
+    "@authx/scopes": ^3.1.0-alpha.36
     "@types/cookies": ^0.7.6
     "@types/http-proxy": ^1.17.5
     "@types/jsonwebtoken": ^8.5.1
@@ -139,8 +139,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@authx/interface@workspace:packages/interface"
   dependencies:
-    "@authx/authx": ^3.1.0-alpha.35
-    "@authx/scopes": ^3.1.0-alpha.35
+    "@authx/authx": ^3.1.0-alpha.36
+    "@authx/scopes": ^3.1.0-alpha.36
     "@types/graphql-react": ^8.1.1
     "@types/html-webpack-plugin": ^3.2.5
     "@types/memory-fs": ^0.3.3
@@ -171,7 +171,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@authx/scopes@^3.1.0-alpha.35, @authx/scopes@workspace:packages/scopes":
+"@authx/scopes@^3.1.0-alpha.36, @authx/scopes@workspace:packages/scopes":
   version: 0.0.0-use.local
   resolution: "@authx/scopes@workspace:packages/scopes"
   dependencies:
@@ -187,12 +187,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@authx/strategy-email@^3.1.0-alpha.35, @authx/strategy-email@workspace:packages/strategy-email":
+"@authx/strategy-email@^3.1.0-alpha.36, @authx/strategy-email@workspace:packages/strategy-email":
   version: 0.0.0-use.local
   resolution: "@authx/strategy-email@workspace:packages/strategy-email"
   dependencies:
-    "@authx/authx": ^3.1.0-alpha.35
-    "@authx/scopes": ^3.1.0-alpha.35
+    "@authx/authx": ^3.1.0-alpha.36
+    "@authx/scopes": ^3.1.0-alpha.36
     "@types/pg": ^7.14.11
     "@types/uuid": ^8.3.0
     "@typescript-eslint/eslint-plugin": ^4.6.1
@@ -216,9 +216,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@authx/strategy-openid@workspace:packages/strategy-openid"
   dependencies:
-    "@authx/authx": ^3.1.0-alpha.35
-    "@authx/scopes": ^3.1.0-alpha.35
-    "@authx/strategy-email": ^3.1.0-alpha.35
+    "@authx/authx": ^3.1.0-alpha.36
+    "@authx/scopes": ^3.1.0-alpha.36
+    "@authx/strategy-email": ^3.1.0-alpha.36
     "@types/pg": ^7.14.11
     "@types/uuid": ^8.3.0
     "@typescript-eslint/eslint-plugin": ^4.6.1
@@ -239,12 +239,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@authx/strategy-password@^3.1.0-alpha.35, @authx/strategy-password@workspace:packages/strategy-password":
+"@authx/strategy-password@^3.1.0-alpha.36, @authx/strategy-password@workspace:packages/strategy-password":
   version: 0.0.0-use.local
   resolution: "@authx/strategy-password@workspace:packages/strategy-password"
   dependencies:
-    "@authx/authx": ^3.1.0-alpha.35
-    "@authx/scopes": ^3.1.0-alpha.35
+    "@authx/authx": ^3.1.0-alpha.36
+    "@authx/scopes": ^3.1.0-alpha.36
     "@types/bcrypt": ^3.0.1
     "@types/pg": ^7.14.11
     "@types/uuid": ^8.3.0
@@ -270,9 +270,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@authx/strategy-saml@workspace:packages/strategy-saml"
   dependencies:
-    "@authx/authx": ^3.1.0-alpha.35
-    "@authx/scopes": ^3.1.0-alpha.35
-    "@authx/strategy-email": ^3.1.0-alpha.35
+    "@authx/authx": ^3.1.0-alpha.36
+    "@authx/scopes": ^3.1.0-alpha.36
+    "@authx/strategy-email": ^3.1.0-alpha.36
     "@types/bcrypt": ^3.0.1
     "@types/pg": ^7.14.11
     "@types/saml2-js": ^2.0.0
@@ -302,8 +302,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@authx/tools@workspace:packages/tools"
   dependencies:
-    "@authx/authx": ^3.1.0-alpha.35
-    "@authx/strategy-password": ^3.1.0-alpha.35
+    "@authx/authx": ^3.1.0-alpha.36
+    "@authx/strategy-password": ^3.1.0-alpha.36
     "@types/pg": ^7.14.11
     "@types/uuid": ^8.3.0
     "@typescript-eslint/eslint-plugin": ^4.6.1


### PR DESCRIPTION
Yarn 3 changed the name of this command: https://yarnpkg.com/cli/npm/publish/#gatsby-focus-wrapper