### PR TITLE
Fix missing files issue

### DIFF
--- a/packages/authx/package.json
+++ b/packages/authx/package.json
@@ -48,6 +48,8 @@
     "node": ">=10"
   },
   "files": [
+    "scopes.js",
+    "scopes.d.ts",
     "dist",
     "!dist/**.test.js",
     "!dist/**.test.js.map",


### PR DESCRIPTION
The cause of the current crash loop on dev seems to be that `scopes.js` and `scopes.d.ts` are missing from `3.1.0-alpha.40`. They were in `3.1.0-alpha.35`. I'm not completely sure what's going on, but my guess is that this has something to do with the upgrade from yarn `1` to `3`. Testing with `yarn pack` confirms that yarn is only pushing files in the `files` block, so this should fix the issue.