### PR TITLE
Invocation Recorder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ package-lock.json
 npm-debug.log
 yarn-error.log
 *.sublime-workspace
+docker-compose.override.yml
 
 /dist
 

--- a/packages/authx/src/Config.ts
+++ b/packages/authx/src/Config.ts
@@ -1,6 +1,7 @@
 import { GraphQLSchema } from "graphql";
 import { StrategyCollection } from "./StrategyCollection";
 import { Strategy } from "./Strategy";
+import { InvocationRecorder } from "./InvocationRecorder";
 
 export interface Config {
   readonly realm: string;
@@ -29,6 +30,7 @@ export interface Config {
   }) => Promise<any>;
   readonly processSchema?: (schema: GraphQLSchema) => GraphQLSchema;
   readonly maxRequestsPerMinute: number | null;
+  readonly invocationRecorder?: InvocationRecorder;
 }
 
 export function assertConfig(config: Config): void {

--- a/packages/authx/src/InvocationRecorder.ts
+++ b/packages/authx/src/InvocationRecorder.ts
@@ -1,0 +1,37 @@
+import { ClientBase, Pool } from "pg";
+import { DataLoaderExecutor } from "./loader";
+import { Authorization, AuthorizationInvocation } from "./model";
+
+export interface InvocationRecorder {
+  /**
+   * Queues an authorization invocation for persistence to the database.
+   * Returns a promise that resolves to an authorization invocation. Note that this
+   * authorization invocation is simply queued, and may not yet be in the database.
+   * @param tx A transaction that the invocation recorder may use to store the invocation in the database. The recorder may
+   *   or may not use this transaction.
+   * @param data
+   */
+  queueAuthorizationInvocation(
+    tx: Pool | ClientBase | DataLoaderExecutor,
+    authorization: Authorization,
+    data: {
+      id: string;
+      format: string;
+      createdAt: Date;
+    }
+  ): Promise<AuthorizationInvocation>;
+}
+
+export class EagerInvocationRecorder implements InvocationRecorder {
+  async queueAuthorizationInvocation(
+    tx: Pool | ClientBase | DataLoaderExecutor,
+    authorization: Authorization,
+    data: {
+      id: string;
+      format: string;
+      createdAt: Date;
+    }
+  ): Promise<AuthorizationInvocation> {
+    return await authorization.invoke(tx, data);
+  }
+}

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -64,6 +64,7 @@
     "lint": "prettier -c '**/*.{json,yml,md,ts}' && eslint src --ext ts",
     "build": "rm -rf dist && mkdir -p dist/client && cp src/client/index.html dist/client/index.html && tsc",
     "build:development": "rm -rf dist && mkdir -p dist/client && ln -s ../../src/client/index.html dist/client/index.html && tsc --watch",
+    "build:development:chained": "rm -rf dist && mkdir -p dist/client && ln -s ../../src/client/index.html dist/client/index.html && tsc --watch --preserveWatchOutput --pretty",
     "start": "NODE_ENV=production node dist/server/server",
     "start:development": "NODE_ENV=development nodemon --inspect dist/server/server",
     "test": "ava --verbose dist/*.test.js",

--- a/src/InvocationRecorder.test.ts
+++ b/src/InvocationRecorder.test.ts
@@ -1,0 +1,77 @@
+import test from "ava";
+import fetch from "node-fetch";
+import { URL } from "url";
+import { setup } from "./setup";
+import { basename } from "path";
+import { InvocationRecorder } from "@authx/authx/dist/InvocationRecorder";
+import { Authorization, AuthorizationInvocation } from "@authx/authx";
+
+class StubInvocationRecorder implements InvocationRecorder {
+  public numCalls = 0;
+
+  async queueAuthorizationInvocation(
+    tx: any,
+    authorization: Authorization,
+    data: {
+      id: string;
+      format: string;
+      createdAt: Date;
+    }
+  ): Promise<AuthorizationInvocation> {
+    this.numCalls++;
+    return {
+      ...data,
+      entityId: "ENT",
+      recordId: "REC",
+    } as AuthorizationInvocation;
+  }
+}
+
+let url: URL;
+let teardown: () => Promise<void>;
+
+let invocationRecorder: StubInvocationRecorder | null = null;
+
+// Setup.
+test.before(async () => {
+  invocationRecorder = new StubInvocationRecorder();
+  const s = await setup(basename(__filename, ".js"), {
+    invocationRecorder,
+  });
+  url = s.url;
+  teardown = s.teardown;
+});
+
+test("InvocationRecorder is called when expected", async (t) => {
+  t.deepEqual(invocationRecorder?.numCalls, 0);
+
+  const graphqlUrl = new URL(url.href);
+  graphqlUrl.pathname = "/graphql";
+
+  const result = await fetch(graphqlUrl.href, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization:
+        "Basic YzcwZGE0OTgtMjdlZC00YzNiLWEzMTgtMzhiYjIyMGNlZjQ4OjhmNTczOTVlY2Q5ZDZmY2I4ODQxNDVmOGY2ZmVmZjM1N2ZlYWQyZmJkODM2MDdlODdkNzFhN2MzNzJjZjM3YWQ=",
+    },
+    body: JSON.stringify({
+      query: /* GraphQL */ `
+        query {
+          viewer {
+            id
+          }
+        }
+      `,
+    }),
+  });
+
+  t.deepEqual(invocationRecorder?.numCalls, 1);
+});
+
+// Teardown.
+test.after.always(async () => {
+  if (teardown) {
+    await teardown();
+  }
+});

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,5 +1,5 @@
 import Koa from "koa";
-import AuthX, { StrategyCollection } from "@authx/authx";
+import AuthX, { Config, StrategyCollection } from "@authx/authx";
 import createAuthXInterface from "@authx/interface";
 
 import email from "@authx/strategy-email";
@@ -60,7 +60,8 @@ async function setupDatabase(namespace: string): Promise<{
 }
 
 async function setupApp(
-  database: string
+  database: string,
+  configOverrides: Partial<Config> = {}
 ): Promise<{ port: number; teardownApp: () => Promise<void> }> {
   // Create a Koa app.
   const app = new Koa();
@@ -126,6 +127,7 @@ Bac/x5qiUn5fh2xM+wIDAQAB
       user: process.env.PGUSER ?? undefined,
     },
     maxRequestsPerMinute: null,
+    ...configOverrides,
   });
 
   // Apply the AuthX routes to the app.
@@ -170,11 +172,12 @@ Bac/x5qiUn5fh2xM+wIDAQAB
 }
 
 export async function setup(
-  namespace: string
+  namespace: string,
+  configOverrides: Partial<Config> = {}
 ): Promise<{ url: URL; teardown: () => Promise<void> }> {
   const { database, teardownDatabase } = await setupDatabase(namespace);
   try {
-    const { port, teardownApp } = await setupApp(database);
+    const { port, teardownApp } = await setupApp(database, configOverrides);
     return {
       url: Object.freeze(new URL(`http://localhost:${port}`)),
       async teardown(): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,11 +14,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@authx/authx@^3.1.0-alpha.42, @authx/authx@workspace:packages/authx":
+"@authx/authx@^3.1.0-alpha.43, @authx/authx@workspace:packages/authx":
   version: 0.0.0-use.local
   resolution: "@authx/authx@workspace:packages/authx"
   dependencies:
-    "@authx/scopes": ^3.1.0-alpha.42
+    "@authx/scopes": ^3.1.0-alpha.43
     "@opencensus/core": ^0.0.22
     "@types/auth-header": ^1.0.1
     "@types/graphql-api-koa": ^2.0.2
@@ -91,7 +91,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@authx/http-proxy-resource@workspace:packages/http-proxy-resource"
   dependencies:
-    "@authx/scopes": ^3.1.0-alpha.42
+    "@authx/scopes": ^3.1.0-alpha.43
     "@types/http-proxy": ^1.17.5
     "@types/jsonwebtoken": ^8.5.1
     "@types/node-fetch": ^2.5.10
@@ -114,7 +114,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@authx/http-proxy-web@workspace:packages/http-proxy-web"
   dependencies:
-    "@authx/scopes": ^3.1.0-alpha.42
+    "@authx/scopes": ^3.1.0-alpha.43
     "@types/cookies": ^0.7.6
     "@types/http-proxy": ^1.17.5
     "@types/jsonwebtoken": ^8.5.1
@@ -139,8 +139,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@authx/interface@workspace:packages/interface"
   dependencies:
-    "@authx/authx": ^3.1.0-alpha.42
-    "@authx/scopes": ^3.1.0-alpha.42
+    "@authx/authx": ^3.1.0-alpha.43
+    "@authx/scopes": ^3.1.0-alpha.43
     "@types/graphql-react": ^8.1.1
     "@types/html-webpack-plugin": ^3.2.5
     "@types/memory-fs": ^0.3.3
@@ -171,7 +171,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@authx/scopes@^3.1.0-alpha.42, @authx/scopes@workspace:packages/scopes":
+"@authx/scopes@^3.1.0-alpha.43, @authx/scopes@workspace:packages/scopes":
   version: 0.0.0-use.local
   resolution: "@authx/scopes@workspace:packages/scopes"
   dependencies:
@@ -187,12 +187,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@authx/strategy-email@^3.1.0-alpha.42, @authx/strategy-email@workspace:packages/strategy-email":
+"@authx/strategy-email@^3.1.0-alpha.43, @authx/strategy-email@workspace:packages/strategy-email":
   version: 0.0.0-use.local
   resolution: "@authx/strategy-email@workspace:packages/strategy-email"
   dependencies:
-    "@authx/authx": ^3.1.0-alpha.42
-    "@authx/scopes": ^3.1.0-alpha.42
+    "@authx/authx": ^3.1.0-alpha.43
+    "@authx/scopes": ^3.1.0-alpha.43
     "@types/pg": ^7.14.11
     "@types/uuid": ^8.3.0
     "@typescript-eslint/eslint-plugin": ^4.6.1
@@ -216,9 +216,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@authx/strategy-openid@workspace:packages/strategy-openid"
   dependencies:
-    "@authx/authx": ^3.1.0-alpha.42
-    "@authx/scopes": ^3.1.0-alpha.42
-    "@authx/strategy-email": ^3.1.0-alpha.42
+    "@authx/authx": ^3.1.0-alpha.43
+    "@authx/scopes": ^3.1.0-alpha.43
+    "@authx/strategy-email": ^3.1.0-alpha.43
     "@types/pg": ^7.14.11
     "@types/uuid": ^8.3.0
     "@typescript-eslint/eslint-plugin": ^4.6.1
@@ -239,12 +239,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@authx/strategy-password@^3.1.0-alpha.42, @authx/strategy-password@workspace:packages/strategy-password":
+"@authx/strategy-password@^3.1.0-alpha.43, @authx/strategy-password@workspace:packages/strategy-password":
   version: 0.0.0-use.local
   resolution: "@authx/strategy-password@workspace:packages/strategy-password"
   dependencies:
-    "@authx/authx": ^3.1.0-alpha.42
-    "@authx/scopes": ^3.1.0-alpha.42
+    "@authx/authx": ^3.1.0-alpha.43
+    "@authx/scopes": ^3.1.0-alpha.43
     "@types/bcrypt": ^3.0.1
     "@types/pg": ^7.14.11
     "@types/uuid": ^8.3.0
@@ -270,9 +270,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@authx/strategy-saml@workspace:packages/strategy-saml"
   dependencies:
-    "@authx/authx": ^3.1.0-alpha.42
-    "@authx/scopes": ^3.1.0-alpha.42
-    "@authx/strategy-email": ^3.1.0-alpha.42
+    "@authx/authx": ^3.1.0-alpha.43
+    "@authx/scopes": ^3.1.0-alpha.43
+    "@authx/strategy-email": ^3.1.0-alpha.43
     "@types/bcrypt": ^3.0.1
     "@types/pg": ^7.14.11
     "@types/saml2-js": ^2.0.0
@@ -302,8 +302,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@authx/tools@workspace:packages/tools"
   dependencies:
-    "@authx/authx": ^3.1.0-alpha.42
-    "@authx/strategy-password": ^3.1.0-alpha.42
+    "@authx/authx": ^3.1.0-alpha.43
+    "@authx/strategy-password": ^3.1.0-alpha.43
     "@types/pg": ^7.14.11
     "@types/uuid": ^8.3.0
     "@typescript-eslint/eslint-plugin": ^4.6.1


### PR DESCRIPTION
Historically, there have been some issues with performance around authorization invocations since each one triggers a write to the database. This change adds in a pluggable "InvocationRecorder" so users can decide to use a different possibly more performant implementation if they want to.

A default EagerInvocationRecorder just follows the current logic, so if users don't add their own implementation, behavior will not change.