### PR TITLE
Fix scope docs

### DIFF
--- a/packages/authx/README.md
+++ b/packages/authx/README.md
@@ -138,7 +138,7 @@ AuthX uses its own authorization system to restrict access to its resources. A s
 For an AuthX resource, the **context** is always in the following format:
 
 ```
-v2.(type).(authority_id).(authorization_id).(client_id).(credential_id).(role_id).(user_id)
+v2.(type).(authority_id).(authorization_id).(client_id).(credential_id).(grant_id).(role_id).(user_id)
 ```
 
 When checking for the ability to perform an action on an entity, the entity's ID and the IDs of related entities are present on the compared scope. When creating a _new_ entity, only the IDs of related entities will be present, and the position of the entity' ID will be empty, even if an ID is specified for the entity in its creation request.


### PR DESCRIPTION
It looks like the `grant_id` segment was omitted in the resource format description, even though it was present in the matrix. This adds it.