### PR TITLE
Allow manual triggering of CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,7 @@
 name: "CodeQL"
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:


### PR DESCRIPTION
This updates the CodsQL workflow to allow direct execution from the `main` branch.