### PR TITLE
Handle invalid URL in http-proxy-web

### DIFF
--- a/packages/http-proxy-web/src/index.test.ts
+++ b/packages/http-proxy-web/src/index.test.ts
@@ -420,3 +420,14 @@ test("fetch token from authx (basic)", async (t) => {
       "Basic NjM3MmRmZjMtMzcwOC00MWMyLWE5ZjQtNjMyZWExNDg1MTZkOjkwNDg5OTExN2M3ZDgwNWE4NGYxM2ZiYzEwNWYxMDhjMDIzMGFhOGM=",
   });
 });
+
+test("does not proxy an invalid URL", async (t) => {
+  const response = await fetch(
+    `http://localhost:${bearerProxyPort}//?this_is_invalid`,
+    {
+      redirect: "manual",
+    },
+  );
+  t.is(response.status, 400);
+  t.regex(await response.text(), /The URL provided is invalid\./);
+});

--- a/packages/http-proxy-web/src/index.ts
+++ b/packages/http-proxy-web/src/index.ts
@@ -317,10 +317,23 @@ export default class AuthXWebProxy extends EventEmitter {
     }
 
     // Serve the client URL.
-    const requestUrl = new URL(
-      request.url || "/",
-      "http://this-does-not-matter",
-    );
+    let requestUrl: URL;
+    try {
+      requestUrl = new URL(request.url || "/", "http://this-does-not-matter");
+    } catch (error) {
+      response.setHeader("Cache-Control", "no-cache");
+      response.statusCode = 400;
+      meta.message = "Request handled by client endpoint: invalid URL.";
+      return send(`
+        <html>
+          <head><title>Error</title></head>
+          <body>
+            <div>The URL provided is invalid.</div>
+          </body>
+        </html>
+      `);
+    }
+
     const clientUrl = new URL(this._config.clientUrl);
     if (requestUrl.pathname === clientUrl.pathname) {
       const params = requestUrl.searchParams;


### PR DESCRIPTION
This ensures that requests to invalid URL's are safely rejected by the "web" proxy.